### PR TITLE
feat: 로그아웃 시 HttpOnly Cookie 삭제 

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
@@ -56,9 +56,14 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @RequestHeader("Authorization") String authHeader,
-            @CookieValue("refresh_token") String refreshToken
+            @CookieValue("refresh_token") String refreshToken,
+            HttpServletResponse response
     ) {
         authService.logout(authHeader.substring(7), refreshToken);
+
+        ResponseCookie clearCookie = createClearRefreshTokenCookie();
+        response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+
         return ResponseEntity.ok(ApiResponse.of(null, "로그아웃이 완료되었습니다."));
     }
 
@@ -94,13 +99,22 @@ public class AuthController {
     }
 
     private static ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
+        return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Strict")
                 .maxAge(Duration.ofDays(7))
                 .path("/api/auth")
                 .build();
-        return cookie;
+    }
+
+    private static ResponseCookie createClearRefreshTokenCookie() {
+        return ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(0)
+                .path("/api/auth")
+                .build();
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/dto/request/SignupRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/dto/request/SignupRequest.java
@@ -1,9 +1,11 @@
 package io.wisoft.ignoa_api.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignupRequest(
         @NotBlank(message = "이메일 입력은 필수입니다.")
+        @Email
         String email,
 
         @NotBlank(message = "비밀번호 입력은 필수입니다.")

--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
@@ -41,11 +41,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private void authenticate(String token) {
         try {
-            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
-
             if (tokenBlacklistService.isBlacklisted(token)) {
                 return;
             }
+
+            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
 
             SecurityContextHolder.getContext().setAuthentication(
                     new UsernamePasswordAuthenticationToken(userId, null, List.of())


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #5

## 📝 작업 내용 (Description)

- 로그아웃 시 HttpOnly Cookie로 설정된 Refresh Token을 서버에서 명시적으로 삭제하도록 개선했습니다.
- 기존에는 Redis에서 RT만 삭제했으나, 브라우저에 쿠키가 7일간 잔존하는 문제가 있었습니다.
- 로그아웃 응답에 `maxAge=0`으로 설정된 쿠키를 내려 브라우저가 즉시 삭제하도록 처리했습니다

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- [로그아웃 시 HttpOnly Cookie는 서버가 삭제해야 한다.](https://familiar-dragon-4ed.notion.site/HttpOnly-Cookie-341bf88cd0f5801b9ccdf19ec9afe537?source=copy_link)

<br>