### PR TITLE
fix: MissingRequestCookieException 500 에러 처리 및 ErrorCode 섹션 정리 

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
@@ -56,9 +56,14 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @RequestHeader("Authorization") String authHeader,
-            @CookieValue("refresh_token") String refreshToken
+            @CookieValue("refresh_token") String refreshToken,
+            HttpServletResponse response
     ) {
         authService.logout(authHeader.substring(7), refreshToken);
+
+        ResponseCookie clearCookie = createClearRefreshTokenCookie();
+        response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+
         return ResponseEntity.ok(ApiResponse.of(null, "로그아웃이 완료되었습니다."));
     }
 
@@ -94,13 +99,22 @@ public class AuthController {
     }
 
     private static ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
+        return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Strict")
                 .maxAge(Duration.ofDays(7))
                 .path("/api/auth")
                 .build();
-        return cookie;
+    }
+
+    private static ResponseCookie createClearRefreshTokenCookie() {
+        return ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(0)
+                .path("/api/auth")
+                .build();
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/dto/request/SignupRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/dto/request/SignupRequest.java
@@ -1,9 +1,11 @@
 package io.wisoft.ignoa_api.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignupRequest(
         @NotBlank(message = "이메일 입력은 필수입니다.")
+        @Email
         String email,
 
         @NotBlank(message = "비밀번호 입력은 필수입니다.")

--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
@@ -41,11 +41,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private void authenticate(String token) {
         try {
-            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
-
             if (tokenBlacklistService.isBlacklisted(token)) {
                 return;
             }
+
+            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
 
             SecurityContextHolder.getContext().setAuthentication(
                     new UsernamePasswordAuthenticationToken(userId, null, List.of())

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -14,14 +14,17 @@ public enum ErrorCode {
     INVALID_PATH_VARIABLE(HttpStatus.BAD_REQUEST, "경로 변수 타입이 올바르지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+
+    // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    MISSING_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 존재하지 않습니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     DUPLICATE_NAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     HAS_ACTIVE_AUCTION(HttpStatus.CONFLICT, "진행 중인 경매가 있어 탈퇴할 수 없습니다."),
     HAS_ACTIVE_BID(HttpStatus.CONFLICT, "진행 중인 경매에 입찰 중이어서 탈퇴할 수 없습니다."),
 

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -56,6 +57,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestCookie(MissingRequestCookieException e) {
+        log.warn("MissingRequestCookieException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.MISSING_REFRESH_TOKEN.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.MISSING_REFRESH_TOKEN));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #7 

## 📝 작업 내용 (Description)

- 로그아웃 후 `/api/auth/refresh` 요청 시 `refresh_token` 쿠키가 없으면
  - `MissingRequestCookieException`이 처리되지 않아 `500`이 응답되는 버그를 수정했습니다.
- `GlobalExceptionHandler`에 핸들러를 추가하여 `401`로 응답하도록 처리했습니다.
- `ErrorCode`의 Auth 관련 코드를 별도 섹션으로 분리했습니다.

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- [Refresh Token을 HttpOnly Cookie에 담아야 하는 이유](https://familiar-dragon-4ed.notion.site/Refresh-Token-HttpOnly-Cookie-33fbf88cd0f5802a85a9f3e7bb317282?source=copy_link)

<br>