### PR TITLE
feat: 회원 탈퇴 30일 유예 및 개인정보 파기 정책 구현

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
@@ -15,7 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.Duration;
+import static io.wisoft.ignoa_api.global.common.CookieUtils.createClearRefreshTokenCookie;
+import static io.wisoft.ignoa_api.global.common.CookieUtils.createRefreshTokenCookie;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -31,6 +32,7 @@ public class AuthController {
             HttpServletResponse response
     ) {
         AuthTokens tokens = authService.signup(request);
+
         ResponseCookie cookie = createRefreshTokenCookie(tokens.refreshToken());
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
@@ -46,6 +48,7 @@ public class AuthController {
             HttpServletResponse response
     ) {
         AuthTokens tokens = authService.login(request);
+
         ResponseCookie cookie = createRefreshTokenCookie(tokens.refreshToken());
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
@@ -73,6 +76,7 @@ public class AuthController {
             HttpServletResponse response
     ) {
         AuthTokens tokens = authService.refresh(refreshToken);
+
         ResponseCookie cookie = createRefreshTokenCookie(tokens.refreshToken());
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
@@ -80,13 +84,26 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.of(data, "액세스 토큰이 재발급되었습니다."));
     }
 
+    @PostMapping("/recover")
+    public ResponseEntity<ApiResponse<LoginResponse>> recover(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        AuthTokens tokens = authService.recover(request);
+
+        ResponseCookie cookie = createRefreshTokenCookie(tokens.refreshToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        LoginResponse data = new LoginResponse(tokens.userId(), tokens.accessToken());
+        return ResponseEntity.ok(ApiResponse.of(data, "계정을 복구하였습니다."));
+    }
+
     @PostMapping("/email/send")
     public ResponseEntity<ApiResponse<Void>> sendEmailCode(
             @Valid @RequestBody EmailVerifyCodeRequest request
     ) {
         emailService.sendEmailCode(request);
-        ApiResponse<Void> response = ApiResponse.of(null, "이메일 인증 코드를 보냈습니다.");
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.of(null, "이메일 인증 코드를 보냈습니다."));
     }
 
     @PostMapping("/email/verify")
@@ -94,27 +111,6 @@ public class AuthController {
             @Valid @RequestBody EmailVerifyRequest request
     ) {
         EmailVerifyResponse data = emailService.verifyEmailCode(request);
-        ApiResponse<EmailVerifyResponse> response = ApiResponse.of(data, "이메일 인증에 성공했습니다.");
-        return ResponseEntity.ok(response);
-    }
-
-    private static ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from("refresh_token", refreshToken)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .maxAge(Duration.ofDays(7))
-                .path("/api/auth")
-                .build();
-    }
-
-    private static ResponseCookie createClearRefreshTokenCookie() {
-        return ResponseCookie.from("refresh_token", "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .maxAge(0)
-                .path("/api/auth")
-                .build();
+        return ResponseEntity.ok(ApiResponse.of(data, "이메일 인증에 성공했습니다."));
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
@@ -64,6 +64,10 @@ public class AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
 
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.ACCOUNT_PENDING_DELETION);
+        }
+
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
         }
@@ -95,4 +99,28 @@ public class AuthService {
 
         return new AuthTokens(userId, accessToken, refreshToken);
     }
+
+    @Transactional
+    public AuthTokens recover(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isDeleted()) {
+            throw new BusinessException(ErrorCode.ACCOUNT_NOT_RECOVERABLE);
+        }
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        user.restore();
+
+        Long userId = user.getId();
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+        refreshTokenService.save(refreshToken, userId);
+
+        return new AuthTokens(userId, accessToken, refreshToken);
+    }
 }
+

--- a/src/main/java/io/wisoft/ignoa_api/global/common/CookieUtils.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/common/CookieUtils.java
@@ -1,0 +1,30 @@
+package io.wisoft.ignoa_api.global.common;
+
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+public class CookieUtils {
+
+    private CookieUtils() {}
+
+    public static ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(Duration.ofDays(7))
+                .path("/api")
+                .build();
+    }
+
+    public static ResponseCookie createClearRefreshTokenCookie() {
+        return ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .maxAge(0)
+                .path("/api")
+                .build();
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/login",
+                                "/api/auth/recover",
                                 "/api/auth/signup",
                                 "/api/auth/refresh",
                                 "/api/auth/email/send",

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     DUPLICATE_NAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     HAS_ACTIVE_AUCTION(HttpStatus.CONFLICT, "진행 중인 경매가 있어 탈퇴할 수 없습니다."),
     HAS_ACTIVE_BID(HttpStatus.CONFLICT, "진행 중인 경매에 입찰 중이어서 탈퇴할 수 없습니다."),
+    ACCOUNT_PENDING_DELETION(HttpStatus.FORBIDDEN, "탈퇴 처리 중인 계정입니다."),
+    ACCOUNT_NOT_RECOVERABLE(HttpStatus.BAD_REQUEST, "복구 가능한 계정이 아닙니다."),
 
     // Email
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
@@ -4,13 +4,18 @@ import io.wisoft.ignoa_api.global.common.ApiResponse;
 import io.wisoft.ignoa_api.user.dto.request.UpdateUserRequest;
 import io.wisoft.ignoa_api.user.dto.response.UserMeResponse;
 import io.wisoft.ignoa_api.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import static io.wisoft.ignoa_api.global.common.CookieUtils.createClearRefreshTokenCookie;
 
 @RestController
 @RequestMapping("/api/users")
@@ -70,10 +75,15 @@ public class UserController {
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<Void>> deleteMe(
             @AuthenticationPrincipal Long userId,
-            @RequestHeader("Refresh-Token") String refreshToken
+            @RequestHeader("Authorization") String authHeader,
+            @CookieValue("refresh_token") String refreshToken,
+            HttpServletResponse response
     ) {
-        userService.deleteMe(userId, refreshToken);
-        ApiResponse<Void> response = ApiResponse.of(null, "회원 탈퇴가 되었습니다.");
-        return ResponseEntity.ok(response);
+        userService.deleteMe(userId, authHeader.substring(7), refreshToken);
+
+        ResponseCookie clearCookie = createClearRefreshTokenCookie();
+        response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+
+        return ResponseEntity.ok(ApiResponse.of(null, "회원 탈퇴가 되었습니다."));
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
@@ -19,7 +19,7 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
     @Column
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column
     private String address;
 
     @Column
@@ -64,10 +64,22 @@ public class User extends BaseEntity {
     }
 
     public void withdraw() {
-        this.email = "withdrawn_" + this.id + "@deleted.com";
-        this.nickname = "탈퇴한 사용자" + this.id;
-        this.address = "";
-        this.password = null;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void purgePersonalData() {
+        this.email = null;
+        this.password = null;
+        this.nickname = "탈퇴한 사용자_" + this.id;
+        this.address = null;
+        this.profileImageUrl = null;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void restore() {
+        this.deletedAt = null;
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package io.wisoft.ignoa_api.user.repository;
 import io.wisoft.ignoa_api.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    List<User> findAllByDeletedAtBefore(LocalDateTime deletedAtBefore);
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,21 @@
+package io.wisoft.ignoa_api.user.scheduler;
+
+import io.wisoft.ignoa_api.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+
+    private final UserService userService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void purgeExpiredWithdrawals() {
+        log.info("탈퇴 회원 개인정보 파기 스케줄러 실행");
+        userService.purgeExpiredWithdrawals();
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserService.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.user.service;
 
 import io.wisoft.ignoa_api.auth.service.RefreshTokenService;
+import io.wisoft.ignoa_api.auth.service.TokenBlacklistService;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
@@ -14,19 +15,27 @@ import io.wisoft.ignoa_api.user.event.ProfileImageDeletedEvent;
 import io.wisoft.ignoa_api.user.repository.UserRepository;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
 
     private final RefreshTokenService refreshTokenService;
+    private final TokenBlacklistService tokenBlacklistService;
     private final StorageService storageService;
+
     private final ApplicationEventPublisher eventPublisher;
+
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final BidRepository bidRepository;
@@ -98,7 +107,7 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteMe(Long userId, String refreshToken) {
+    public void deleteMe(Long userId, String accessToken, String refreshToken) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -110,13 +119,22 @@ public class UserService {
             throw new BusinessException(ErrorCode.HAS_ACTIVE_BID);
         }
 
-        wishRepository.deleteAllByUserId(userId);
+        tokenBlacklistService.blacklist(accessToken);
         refreshTokenService.delete(refreshToken);
-
-        if (user.getProfileImageUrl() != null) {
-            eventPublisher.publishEvent(new ProfileImageDeletedEvent(user.getProfileImageUrl()));
-        }
-
         user.withdraw();
+    }
+
+    @Transactional
+    public void purgeExpiredWithdrawals() {
+        List<User> expiredUsers = userRepository.findAllByDeletedAtBefore(LocalDateTime.now().minusDays(30));
+
+        for (User user: expiredUsers) {
+            if (user.getProfileImageUrl() != null) {
+                eventPublisher.publishEvent(new ProfileImageDeletedEvent(user.getProfileImageUrl()));
+            }
+            wishRepository.deleteAllByUserId(user.getId());
+            user.purgePersonalData();
+            log.info("탈퇴 회원 개인정보 파기 완료 - userId: {}", user.getId());
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #9 

## 📝 작업 내용 (Description)

  회원 탈퇴 시 즉시 삭제 대신 30일 유예 기간을 두고, 기간 경과 후 개인정보를 `null`로 파기하는 방식으로 변경합니다.

  - 탈퇴 신청 시 `deleted_at` 설정 후 데이터 보존 (30일 유예)
  - 30일 이내 로그인 시도 시 계정 복구 안내 (`ACCOUNT_PENDING_DELETION`)
  - `POST /api/auth/recover` — 이메일·비밀번호 검증 후 계정 복구 및 AT/RT 재발급
  - 매일 00:00 스케줄러 실행 — 30일 경과 유저 개인정보 `null` 파기 (`email`, `password`, `address`, `profile_image_url`)
  - 탈퇴 시 AT 블랙리스트 처리 추가
  - RT HttpOnly Cookie path `/api/auth` → `/api` 변경 (탈퇴 엔드포인트 쿠키 전송 보장)
  - Cookie 생성 로직 CookieUtils로 분리
  - [회원 탈퇴 후, 재가입을 어떻게 다뤄야 하는가?](https://familiar-dragon-4ed.notion.site/342bf88cd0f580129fb4d11d98b7f19a?source=copy_link)


## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- 30일 유예 기간 및 파기 사실은 개인정보 처리방침에 명시 필요합니다.
- 거래 기록(`bid`, `item`)은 전자상거래법 5년 보존 의무에 따라 유지되며, 탈퇴 유저는 `"탈퇴한 사용자_" + id` 로 표시됩니다.