### PR TITLE
feat: JWT 인증 보안 강화 (RT 재사용 감지, AT 재파싱 제거, 401/403 분기)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package io.wisoft.ignoa_api.auth.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.wisoft.ignoa_api.auth.service.TokenBlacklistService;
 import jakarta.servlet.FilterChain;
@@ -45,10 +46,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
+            Claims claims = jwtTokenProvider.parseToken(token);
+            long userId = Long.parseLong(claims.getSubject());
 
             SecurityContextHolder.getContext().setAuthentication(
-                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+                    new UsernamePasswordAuthenticationToken(userId, claims, List.of())
             );
 
         } catch (JwtException e) {

--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtTokenProvider.java
@@ -43,4 +43,8 @@ public class JwtTokenProvider {
     public Claims parseToken(String token) {
         return jwtParser.parseSignedClaims(token).getPayload();
     }
+
+    public void validateToken(String token) {
+        jwtParser.parseSignedClaims(token);
+    }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
@@ -88,8 +88,12 @@ public class AuthService {
     }
 
     public AuthTokens refresh(String token) {
-        jwtTokenProvider.parseToken(token);
-        Long userId = refreshTokenService.getUserId(token);
+        Long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
+
+        if (!refreshTokenService.exists(token)) {
+            refreshTokenService.deleteAllByUserId(userId);
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
 
         String accessToken = jwtTokenProvider.createAccessToken(userId);
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
@@ -82,7 +82,7 @@ public class AuthService {
     }
 
     public void logout(String accessToken, String refreshToken) {
-        jwtTokenProvider.parseToken(refreshToken);
+        jwtTokenProvider.validateToken(refreshToken);
         tokenBlacklistService.blacklist(accessToken);
         refreshTokenService.delete(refreshToken);
     }

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/RefreshTokenService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/RefreshTokenService.java
@@ -4,6 +4,7 @@ import io.wisoft.ignoa_api.auth.jwt.JwtProperties;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -38,4 +39,22 @@ public class RefreshTokenService {
     public void delete(String refreshToken) {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + refreshToken);
     }
+
+    public boolean exists(String refreshToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_PREFIX + refreshToken));
+    }
+
+    public void deleteAllByUserId(Long userId) {
+        String pattern = REFRESH_TOKEN_PREFIX + "*";
+        String targetUserId = String.valueOf(userId);
+
+        redisTemplate.scan(ScanOptions.scanOptions().match(pattern).build())
+                .forEachRemaining(key -> {
+                    if(targetUserId.equals(redisTemplate.opsForValue().get(key))) {
+                        redisTemplate.delete(key);
+                    }
+                });
+    }
 }
+
+

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/TokenBlacklistService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/TokenBlacklistService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.wisoft.ignoa_api.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -13,12 +14,13 @@ import java.time.Duration;
 public class TokenBlacklistService {
 
     private static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "bl:";
-
     private final StringRedisTemplate redisTemplate;
-    private final JwtTokenProvider jwtTokenProvider;
 
     public void blacklist(String accessToken) {
-        Claims claims = jwtTokenProvider.parseToken(accessToken);
+        Claims claims = (Claims) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getCredentials();
+
         long remainingMillis = claims.getExpiration().getTime() - System.currentTimeMillis();
 
         redisTemplate.opsForValue()
@@ -31,3 +33,5 @@ public class TokenBlacklistService {
         return redisTemplate.opsForValue().get(ACCESS_TOKEN_BLACKLIST_PREFIX + accessToken) != null;
     }
 }
+
+

--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.global.config;
 
 import io.wisoft.ignoa_api.auth.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,7 +41,12 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/ws").permitAll()
                         .anyRequest().authenticated()
-                ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                ).exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN)))
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #11
- resolves: #12
- resolves: #13

## 📝 작업 내용 (Description)

  > JWT 인증 흐름에서 발견된 보안 이슈 3가지를 수정합니다.

  **1. RT 재사용 감지**
  - `refresh()` 에서 userId를 JWT 클레임에서 직접 추출하도록 변경
  - Redis에 없는 RT로 재발급 시도 시 해당 유저의 전체 세션 무효화
  - 토큰 탈취 후 재사용 공격 방어

  **2. Filter 통과 AT 재파싱 제거**
  - `JwtAuthenticationFilter` 에서 파싱한 claims를 `credentials` 에 저장
  - `TokenBlacklistService` 가 SecurityContextHolder에서 `claims`를 꺼내 사용
  - AT 만료 시간 계산을 위한 불필요한 재파싱 제거

  **3. 401/403 응답 코드 명시적 분기**
  - `SecurityConfig` 에 `exceptionHandling` 설정 추가
  - anonymous 접근 → `401`, 인증된 유저 권한 없음 → `403`

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- [탈취된 Refresh Token, 재사용으로 감지하기](https://familiar-dragon-4ed.notion.site/Refresh-Token-342bf88cd0f580c89ec4cec79a31f755?source=copy_link)
- [Filter를 통과한 Access Token을 서비스에서 재파싱하면 안 되는 이유](https://familiar-dragon-4ed.notion.site/Filter-Access-Token-342bf88cd0f5806fb7c9c81e550245cd?source=copy_link)
- [Spring Security에서 인증되지 않은 요청이 401이 아닌 403으로 반환되는 이유](https://familiar-dragon-4ed.notion.site/Spring-Security-401-403-342bf88cd0f5806fb7c9c81e550245cd?source=copy_link)