### PR TITLE
feat: 카카오 OAuth 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,5 @@ db/
 
 # AI
 CLAUDE.md
-
+.claude
 docs/

--- a/src/main/java/io/wisoft/ignoa_api/IgnoaApiApplication.java
+++ b/src/main/java/io/wisoft/ignoa_api/IgnoaApiApplication.java
@@ -1,13 +1,14 @@
 package io.wisoft.ignoa_api;
 
 import io.wisoft.ignoa_api.auth.jwt.JwtProperties;
+import io.wisoft.ignoa_api.auth.oauth.KakaoProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, KakaoProperties.class})
 @SpringBootApplication
 public class IgnoaApiApplication {
 

--- a/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/controller/AuthController.java
@@ -6,8 +6,10 @@ import io.wisoft.ignoa_api.auth.dto.response.EmailVerifyResponse;
 import io.wisoft.ignoa_api.auth.dto.response.LoginResponse;
 import io.wisoft.ignoa_api.auth.dto.response.RefreshResponse;
 import io.wisoft.ignoa_api.auth.dto.response.SignupResponse;
+import io.wisoft.ignoa_api.auth.oauth.KakaoLoginRequest;
 import io.wisoft.ignoa_api.auth.service.AuthService;
 import io.wisoft.ignoa_api.auth.service.EmailService;
+import io.wisoft.ignoa_api.auth.oauth.KakaoAuthService;
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -24,6 +26,7 @@ import static io.wisoft.ignoa_api.global.common.CookieUtils.createRefreshTokenCo
 public class AuthController {
 
     private final AuthService authService;
+    private final KakaoAuthService kakaoAuthService;
     private final EmailService emailService;
 
     @PostMapping("/signup")
@@ -112,5 +115,19 @@ public class AuthController {
     ) {
         EmailVerifyResponse data = emailService.verifyEmailCode(request);
         return ResponseEntity.ok(ApiResponse.of(data, "이메일 인증에 성공했습니다."));
+    }
+
+    @PostMapping("/oauth/kakao")
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request,
+            HttpServletResponse response
+    ) {
+        AuthTokens tokens = kakaoAuthService.login(request.code());
+
+        ResponseCookie cookie = createRefreshTokenCookie(tokens.refreshToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        LoginResponse data = new LoginResponse(tokens.userId(), tokens.accessToken());
+        return ResponseEntity.ok(ApiResponse.of(data, "카카오 소셜 로그인에 성공했습니다."));
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoAuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoAuthService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,27 +31,48 @@ public class KakaoAuthService {
 
         // 2. 카카오 AT로 사용자 정보 조회
         KakaoUserInfoResponse userInfo = kakaoOAuthClient.getUserInfo(kakaoAccessToken);
+        validateEmail(userInfo.email());
+        String nickname = resolveNickname(userInfo.nickname());
 
-        // 3. 이메일로 기존 유저 조회 -> 없으면 자동 가입
-        User user = userRepository.findByEmail(userInfo.email())
-                .orElseGet(() -> userRepository.save(User.ofKakao(
-                        userInfo.email(),
-                        userInfo.nickname(),
-                        userInfo.profileImageUrl(),
-                        String.valueOf(userInfo.id())))
-                );
+        // 3. OAuth(Provider + OAuthId) 기존 유저 조회 -> 없으면 자동 가입
+        User user = findOrCreateUser(userInfo, nickname);
 
+        // 4. 탈퇴한 회원 처리 로직
         if (user.isDeleted()) {
             throw new BusinessException(ErrorCode.ACCOUNT_PENDING_DELETION);
         }
 
-        // 4. JWT 발급
+        // 5. JWT 발급
         Long userId = user.getId();
         String accessToken = jwtTokenProvider.createAccessToken(userId);
-        String refreshToken = jwtTokenProvider.createRefreshToken((userId));
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
         refreshTokenService.save(refreshToken, userId);
 
-        // 5. AuthTokens 발급
         return new AuthTokens(userId, accessToken, refreshToken);
+    }
+
+    private User findOrCreateUser(KakaoUserInfoResponse userInfo, String nickname) {
+        return userRepository.findByProviderAndOauthId("KAKAO", String.valueOf(userInfo.id()))
+                .orElseGet(() -> userRepository.save(User.ofKakao(
+                        userInfo.email(),
+                        nickname,
+                        userInfo.profileImageUrl(),
+                        String.valueOf(userInfo.id()))));
+    }
+
+    private void validateEmail(String email) {
+        if (email == null) {
+            throw new BusinessException(ErrorCode.KAKAO_EMAIL_REQUIRED);
+        }
+    }
+
+    private String resolveNickname(String kakaoNickname) {
+        String base = kakaoNickname != null ? kakaoNickname : "카카오 사용자";
+
+        if (!userRepository.existsByNickname(base)) {
+            return base;
+        }
+
+        return base + "_" + UUID.randomUUID().toString().substring(0, 6);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoAuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoAuthService.java
@@ -1,0 +1,55 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import io.wisoft.ignoa_api.auth.dto.AuthTokens;
+import io.wisoft.ignoa_api.auth.jwt.JwtTokenProvider;
+import io.wisoft.ignoa_api.auth.service.RefreshTokenService;
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KakaoAuthService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public AuthTokens login(String code) {
+        // 1. 인가 코드로 카카오 AT 교환
+        String kakaoAccessToken = kakaoOAuthClient.getAccessToken(code);
+
+        // 2. 카카오 AT로 사용자 정보 조회
+        KakaoUserInfoResponse userInfo = kakaoOAuthClient.getUserInfo(kakaoAccessToken);
+
+        // 3. 이메일로 기존 유저 조회 -> 없으면 자동 가입
+        User user = userRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> userRepository.save(User.ofKakao(
+                        userInfo.email(),
+                        userInfo.nickname(),
+                        userInfo.profileImageUrl(),
+                        String.valueOf(userInfo.id())))
+                );
+
+        if (user.isDeleted()) {
+            throw new BusinessException(ErrorCode.ACCOUNT_PENDING_DELETION);
+        }
+
+        // 4. JWT 발급
+        Long userId = user.getId();
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+        String refreshToken = jwtTokenProvider.createRefreshToken((userId));
+        refreshTokenService.save(refreshToken, userId);
+
+        // 5. AuthTokens 발급
+        return new AuthTokens(userId, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoLoginRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoLoginRequest.java
@@ -1,0 +1,8 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank String code
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoOAuthClient.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoOAuthClient.java
@@ -1,0 +1,49 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final KakaoProperties kakaoProperties;
+    private final RestClient restClient;
+
+    public String getAccessToken(String code) {
+        KakaoTokenResponse response = restClient.post()
+                .uri(kakaoProperties.tokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body("grant_type=authorization_code" +
+                      "&client_id=" + kakaoProperties.clientId() +
+                      "&client_secret=" + kakaoProperties.clientSecret() +
+                      "&redirect_uri=" + kakaoProperties.redirectUri() +
+                      "&code=" + code)
+                .retrieve()
+                .onStatus(status -> status.isError(), (req, res) -> {
+                    log.error("카카오 토큰 교환 실패 - status: {}, body: {}", res.getStatusCode(), new String(res.getBody().readAllBytes()));
+                    throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+                })
+                .body(KakaoTokenResponse.class);
+
+        return response.accessToken();
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(kakaoProperties.userInfoUri())
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(status -> status.isError(), (req, res) -> {
+                    log.error("카카오 사용자 정보 조회 실패 - status: {}, body: {}", res.getStatusCode(), new String(res.getBody().readAllBytes()));
+                    throw new BusinessException(ErrorCode.KAKAO_AUTH_FAILED);
+                })
+                .body(KakaoUserInfoResponse.class);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoProperties.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoProperties.java
@@ -1,0 +1,13 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String tokenUri,
+        String userInfoUri
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoTokenResponse.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoTokenResponse.java
@@ -1,0 +1,8 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token") String accessToken
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoUserInfoResponse.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoUserInfoResponse.java
@@ -8,14 +8,23 @@ public record KakaoUserInfoResponse(
 ) {
 
     public String email() {
+        if (kakaoAccount() == null) {
+            return null;
+        }
         return kakaoAccount().email();
     }
 
     public String nickname() {
+        if (kakaoAccount() == null || kakaoAccount().profile() == null) {
+            return null;
+        }
         return kakaoAccount().profile().nickname();
     }
 
     public String profileImageUrl() {
+        if (kakaoAccount() == null || kakaoAccount().profile() == null) {
+            return null;
+        }
         return kakaoAccount().profile().profileImageUrl();
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoUserInfoResponse.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/oauth/KakaoUserInfoResponse.java
@@ -1,0 +1,31 @@
+package io.wisoft.ignoa_api.auth.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+
+    public String email() {
+        return kakaoAccount().email();
+    }
+
+    public String nickname() {
+        return kakaoAccount().profile().nickname();
+    }
+
+    public String profileImageUrl() {
+        return kakaoAccount().profile().profileImageUrl();
+    }
+
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname,
+                @JsonProperty("profile_image_url") String profileImageUrl
+        ) {}
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/config/RestClientConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package io.wisoft.ignoa_api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                                 "/api/auth/refresh",
                                 "/api/auth/email/send",
                                 "/api/auth/email/verify",
+                                "/api/auth/oauth/kakao",
                                 "/api/users/email/duplicate",
                                 "/api/users/nickname/duplicate"
                         ).permitAll()

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 
     // OAuth
     KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "카카오 인증에 실패했습니다."),
+    KAKAO_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "카카오 계정의 이메일 제공 동의가 필요합니다."),
 
     // Email
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     ACCOUNT_PENDING_DELETION(HttpStatus.FORBIDDEN, "탈퇴 처리 중인 계정입니다."),
     ACCOUNT_NOT_RECOVERABLE(HttpStatus.BAD_REQUEST, "복구 가능한 계정이 아닙니다."),
 
+    // OAuth
+    KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "카카오 인증에 실패했습니다."),
+
     // Email
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
@@ -51,6 +51,16 @@ public class User extends BaseEntity {
         this.provider = "LOCAL";
     }
 
+    public static User ofKakao(String email, String nickname, String profileImageUrl, String oauthId) {
+        User user = new User();
+        user.email = email;
+        user.nickname =nickname;
+        user.profileImageUrl = profileImageUrl;
+        user.provider = "KAKAO";
+        user.oauthId = oauthId;
+        return user;
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     List<User> findAllByDeletedAtBefore(LocalDateTime deletedAtBefore);
+
+    Optional<User> findByProviderAndOauthId(String provider, String oauthId);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,3 +47,11 @@ jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${JWT_ACCESS_EXPIRATION}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #16 

## 📝 작업 내용 (Description)

- 카카오 인가 코드 방식 소셜 로그인 구현. 신규 유저는 자동 가입, 기존 유저는 로그인
- 처리. 닉네임 중복 시 suffix 자동 부여, 이메일 미동의 시 예외 처리.

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [x] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

  - findByProviderAndOauthId 기반 조회로 탈퇴 후 재가입 케이스 정상 처리
  - 카카오 닉네임 중복 시 UUID suffix 자동 부여로 DB 제약 위반 방어
  - KakaoUserInfoResponse null 안전성 처리 (kakao_account 미동의 케이스)