### PR TITLE
fix: Access / Refresh 토큰 타입 구분 추가 

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtAuthenticationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
+            long userId = Long.parseLong(jwtTokenProvider.parseAccessToken(token).getSubject());
 
             SecurityContextHolder.getContext().setAuthentication(
                     new UsernamePasswordAuthenticationToken(userId, null, List.of())

--- a/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/jwt/JwtTokenProvider.java
@@ -22,29 +22,42 @@ public class JwtTokenProvider {
     }
 
     public String createRefreshToken(Long userId) {
-        return createToken(userId, jwtProperties.refreshExpiration());
+        return createToken(userId, "refresh", jwtProperties.refreshExpiration());
     }
 
     public String createAccessToken(Long userId) {
-        return createToken(userId, jwtProperties.accessExpiration());
+        return createToken(userId, "access", jwtProperties.accessExpiration());
     }
 
-    private String createToken(Long userId, long expiration) {
+    private String createToken(Long userId, String type, long expiration) {
         Date now = new Date();
 
         return Jwts.builder()
                 .subject(String.valueOf(userId))
+                .claim("type", type)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expiration))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public Claims parseToken(String token) {
-        return jwtParser.parseSignedClaims(token).getPayload();
+    public Claims parseAccessToken(String token) {
+        Claims claims = parseToken(token);
+        if (!"access".equals(claims.get("type", String.class))) {
+            throw new JwtException("Not an access Token");
+        }
+        return claims;
     }
 
-    public void validateToken(String token) {
-        jwtParser.parseSignedClaims(token);
+    public Claims parseRefreshToken(String token) {
+        Claims claims = parseToken(token);
+        if (!"refresh".equals(claims.get("type", String.class))) {
+            throw new JwtException("Not an refresh Token");
+        }
+        return claims;
+    }
+
+    private Claims parseToken(String token) {
+        return jwtParser.parseSignedClaims(token).getPayload();
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
@@ -82,13 +82,13 @@ public class AuthService {
     }
 
     public void logout(String accessToken, String refreshToken) {
-        jwtTokenProvider.validateToken(refreshToken);
+        jwtTokenProvider.parseRefreshToken(refreshToken);
         tokenBlacklistService.blacklist(accessToken);
         refreshTokenService.delete(refreshToken);
     }
 
     public AuthTokens refresh(String token) {
-        Long userId = Long.parseLong(jwtTokenProvider.parseToken(token).getSubject());
+        Long userId = Long.parseLong(jwtTokenProvider.parseRefreshToken(token).getSubject());
 
         if (!refreshTokenService.exists(token)) {
             refreshTokenService.deleteAllByUserId(userId);

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/TokenBlacklistService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/TokenBlacklistService.java
@@ -17,7 +17,7 @@ public class TokenBlacklistService {
     private final JwtTokenProvider jwtTokenProvider;
 
     public void blacklist(String accessToken) {
-        Claims claims = jwtTokenProvider.parseToken(accessToken);
+        Claims claims = jwtTokenProvider.parseAccessToken(accessToken);
         long remainingMillis =
                 claims.getExpiration().getTime() - System.currentTimeMillis();
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #25 

## 📝 작업 내용 (Description)

  - `createToken()`에 `type` claim 추가 (`"access"` / `"refresh"`)
  - `parseAccessToken()` / `parseRefreshToken()` 메서드 분리, 각각 type 불일치 시 예외 발생
  - `JwtAuthenticationFilter`에서 `parseAccessToken()` 사용 → Refresh Token으로 API 인증 불가
  - `AuthService.refresh()` / `logout()`에서 `parseRefreshToken()` 사용 → Access Token 사용 시 예외
  - 기존 `validateToken()` 제거 (`parseRefreshToken()`으로 대체)


## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- [Access / Refresh 토큰 타입 구분으로 토큰 혼용 공격 차단하기](https://familiar-dragon-4ed.notion.site/Access-Refresh-34abf88cd0f580f39b74c53604df9c24?source=copy_link)