### PR TITLE
fix: Refresh 토큰 소비 원자화 (TOCTOU)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/AuthService.java
@@ -88,20 +88,21 @@ public class AuthService {
     }
 
     public AuthTokens refresh(String token) {
-        Long userId = Long.parseLong(jwtTokenProvider.parseRefreshToken(token).getSubject());
+        jwtTokenProvider.parseRefreshToken(token);
 
-        if (!refreshTokenService.exists(token)) {
+        Long consumedUserId = refreshTokenService.consumeToken(token);
+
+        if (consumedUserId == null) {
+            long userId = Long.parseLong(jwtTokenProvider.parseRefreshToken(token).getSubject());
             refreshTokenService.deleteAllByUserId(userId);
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
 
-        String accessToken = jwtTokenProvider.createAccessToken(userId);
-        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+        String accessToken = jwtTokenProvider.createAccessToken(consumedUserId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(consumedUserId);
+        refreshTokenService.save(refreshToken, consumedUserId);
 
-        refreshTokenService.delete(token);
-        refreshTokenService.save(refreshToken, userId);
-
-        return new AuthTokens(userId, accessToken, refreshToken);
+        return new AuthTokens(consumedUserId, accessToken, refreshToken);
     }
 
     @Transactional

--- a/src/main/java/io/wisoft/ignoa_api/auth/service/RefreshTokenService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auth/service/RefreshTokenService.java
@@ -1,8 +1,6 @@
 package io.wisoft.ignoa_api.auth.service;
 
 import io.wisoft.ignoa_api.auth.jwt.JwtProperties;
-import io.wisoft.ignoa_api.global.exception.BusinessException;
-import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -27,21 +25,8 @@ public class RefreshTokenService {
                 );
     }
 
-    public Long getUserId(String refreshToken) {
-        String userId = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + refreshToken);
-
-        if (userId == null) {
-            throw new BusinessException(ErrorCode.INVALID_TOKEN);
-        }
-        return Long.parseLong(userId);
-    }
-
     public void delete(String refreshToken) {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + refreshToken);
-    }
-
-    public boolean exists(String refreshToken) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_TOKEN_PREFIX + refreshToken));
     }
 
     public void deleteAllByUserId(Long userId) {
@@ -54,6 +39,13 @@ public class RefreshTokenService {
                         redisTemplate.delete(key);
                     }
                 });
+    }
+
+    public Long consumeToken(String refreshToken) {
+        String userId = redisTemplate.opsForValue()
+                .getAndDelete(REFRESH_TOKEN_PREFIX + refreshToken);
+
+        return userId != null ? Long.parseLong(userId) : null;
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #26

## 📝 작업 내용 (Description)

> 기존 `exists()` + `delete()` 패턴은 두 연산 사이에 동일한 토큰으로 동시 요청이 들어올 경우 둘 다 통과하여 세션이 복제되는 문제가 있었습니다.

  - RefreshTokenService에 `consumeToken()` 추가 (Redis GETDEL로 원자적 소비)
  - AuthService.refresh()에서 `consumeToken()`으로 교체
  - 미사용 메서드 `exists()`, `getUserId()` 제거

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- [Refresh Token 동시 요청의 TOCTOU, 원자석 소비로 방지하기](https://familiar-dragon-4ed.notion.site/Refresh-Token-TOCTOU-34abf88cd0f580a78f8cd7f55445c363?source=copy_link)