### PR TITLE
fix: 탈퇴 회원 개인정보 파기 스케줄러 OOM 및 트랜잭션 분리

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
@@ -67,11 +67,11 @@ public class UserController {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UserMeResponse>> patchMe(
+    public ResponseEntity<ApiResponse<UserMeResponse>> updateProfile(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody UpdateUserRequest request
     ) {
-        UserMeResponse data = userCommandService.patchMe(userId, request);
+        UserMeResponse data = userCommandService.updateProfile(userId, request);
         ApiResponse<UserMeResponse> response = ApiResponse.of(data, "유저 정보가 수정되었습니다.");
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
@@ -1,7 +1,12 @@
 package io.wisoft.ignoa_api.user.repository;
 
 import io.wisoft.ignoa_api.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,4 +23,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByDeletedAtBefore(LocalDateTime deletedAtBefore);
 
     Optional<User> findByProviderAndOauthId(String provider, String oauthId);
+
+    @Query("""
+                    SELECT u 
+                    FROM User u
+                    WHERE u.deletedAt >= :startDateTime
+                      AND u.deletedAt < :endDateTime
+                      AND u.id > :lastId
+                    ORDER BY u.id ASC    
+            """)
+    List<User> findPurgeTargets(@Param("startDateTime") LocalDateTime startDateTime,
+                                @Param("endDateTime") LocalDateTime endDateTime,
+                                @Param("lastId") Long lastId,
+                                Pageable pageable);
 }
+

--- a/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserCleanupScheduler.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.user.scheduler;
 
 import io.wisoft.ignoa_api.user.service.UserCommandService;
+import io.wisoft.ignoa_api.user.service.UserPurgeJob;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,11 +12,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserCleanupScheduler {
 
-    private final UserCommandService userService;
+    private final UserPurgeJob userPurgeJob;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void purgeExpiredWithdrawals() {
         log.info("탈퇴 회원 개인정보 파기 스케줄러 실행");
-        userService.purgeExpiredWithdrawals();
+        userPurgeJob.execute();
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
@@ -14,13 +14,9 @@ import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -83,11 +79,14 @@ public class UserCommandService {
     }
 
     public void purgeUser(User user) {
+        String profileImageUrl = user.getProfileImageUrl();
+
         wishRepository.deleteAllByUserId(user.getId());
         user.purgePersonalData();
+        userRepository.save(user);
 
-        if (user.getProfileImageUrl() != null) {
-            eventPublisher.publishEvent(new ProfileImageDeletedEvent(user.getProfileImageUrl()));
+        if (profileImageUrl != null) {
+            eventPublisher.publishEvent(new ProfileImageDeletedEvent(profileImageUrl));
         }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
@@ -14,9 +14,11 @@ import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -54,7 +56,7 @@ public class UserCommandService {
         eventPublisher.publishEvent(new ProfileImageDeletedEvent(profileImageUrl));
     }
 
-    public UserMeResponse patchMe(Long userId, UpdateUserRequest request) {
+    public UserMeResponse updateProfile(Long userId, UpdateUserRequest request) {
         User user = userQueryService.findById(userId);
 
         if (request.nickname() != null && userRepository.existsByNickname(request.nickname())) {
@@ -80,16 +82,12 @@ public class UserCommandService {
         user.withdraw();
     }
 
-    public void purgeExpiredWithdrawals() {
-        List<User> expiredUsers = userRepository.findAllByDeletedAtBefore(LocalDateTime.now().minusDays(30));
+    public void purgeUser(User user) {
+        wishRepository.deleteAllByUserId(user.getId());
+        user.purgePersonalData();
 
-        for (User user : expiredUsers) {
-            if (user.getProfileImageUrl() != null) {
-                eventPublisher.publishEvent(new ProfileImageDeletedEvent(user.getProfileImageUrl()));
-            }
-            wishRepository.deleteAllByUserId(user.getId());
-            user.purgePersonalData();
-            log.info("탈퇴 회원 개인정보 파기 완료 - userId: {}", user.getId());
+        if (user.getProfileImageUrl() != null) {
+            eventPublisher.publishEvent(new ProfileImageDeletedEvent(user.getProfileImageUrl()));
         }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserPurgeJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserPurgeJob.java
@@ -1,0 +1,54 @@
+package io.wisoft.ignoa_api.user.service;
+
+import io.wisoft.ignoa_api.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserPurgeJob {
+
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+
+    public void execute() {
+        final int BATCH_SIZE = 500;
+        Long lastId = 0L;
+
+        int successCount = 0;
+        int failCount = 0;
+        int totalTargetCount = 0;
+
+        LocalDate targetDate = LocalDate.now().minusDays(30);
+        LocalDateTime startDateTime = targetDate.atStartOfDay();
+        LocalDateTime endDateTime = targetDate.plusDays(1).atStartOfDay();
+
+        while (true) {
+            List<User> users = userQueryService.findPurgeTargets(startDateTime, endDateTime, lastId, BATCH_SIZE);
+
+            if (users.isEmpty()) {
+                break;
+            }
+
+            for (User user : users) {
+                lastId = user.getId();
+                totalTargetCount++;
+
+                try {
+                    userCommandService.purgeUser(user);
+                    successCount++;
+                    log.info("탈퇴 회원 개인정보 파기 완료 - userId: {}", user.getId());
+                } catch (Exception e) {
+                    failCount++;
+                    log.warn("탈퇴 회원 개인정보 파기 실패 - userId: {}", user.getId(), e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserQueryService.java
@@ -7,8 +7,12 @@ import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -37,5 +41,9 @@ public class UserQueryService {
 
     public UserMeResponse getMe(Long userId) {
         return UserMeResponse.from(findById(userId));
+    }
+
+    public List<User> findPurgeTargets(LocalDateTime startDateTime, LocalDateTime endDateTime, Long lastId, int batchSize) {
+        return userRepository.findPurgeTargets(startDateTime, endDateTime, lastId, PageRequest.of(0, batchSize));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #35 

## 📝 작업 내용 (Description)

  **변경 전**
  - 탈퇴 대상 전체를 한 번에 메모리에 올려 OOM 위험
  - 전체 처리가 하나의 트랜잭션으로 묶여 DB 커넥션 장시간 점유
  - 30일 이전 전체 조회로 이미 파기된 회원도 반복 조회

  **변경 후**
  - 조회 범위를 정확히 30일 전 하루로 좁힘
  - Cursor 기반 청크 처리(500명씩)로 OOM 방지
  - `UserPurgeJob`으로 분리해 while 루프를 트랜잭션 밖에서 실행
  - `UserCommandService.purgeUser()`로 유저 1명씩 독립 트랜잭션 처리

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- 파기 실패 건은 현재 `log.warn`으로만 기록하며, 추후 Outbox 패턴으로 재처리 예정