### PR TITLE
feat: 스케줄러 중복 실행 방지 ShedLock 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.26.12'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// Shedlock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.0.2'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.0.2'
+
 	// 개발 편의
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
@@ -4,6 +4,7 @@ package io.wisoft.ignoa_api.auction.scheduler;
 import io.wisoft.ignoa_api.auction.service.AuctionCloseProcessor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,7 @@ public class AuctionCloseScheduler {
     private final AuctionCloseProcessor auctionCloseProcessor;
 
     @Scheduled(cron = "0 */5 * * * *")
+    @SchedulerLock(name = "auctionCloseScheduler")
     public void closeExpiredBids() {
         log.info("경매 마감 스케줄러 실행");
         auctionCloseProcessor.closeExpiredBids();

--- a/src/main/java/io/wisoft/ignoa_api/global/config/ShedLockConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/ShedLockConfig.java
@@ -1,0 +1,18 @@
+package io.wisoft.ignoa_api.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
+public class ShedLockConfig {
+
+    @Bean
+    LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/outbox/scheduler/OutboxScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/outbox/scheduler/OutboxScheduler.java
@@ -3,6 +3,7 @@ package io.wisoft.ignoa_api.global.outbox.scheduler;
 import io.wisoft.ignoa_api.global.outbox.service.OutboxWorker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ public class OutboxScheduler {
     private final OutboxWorker outboxWorker;
 
     @Scheduled(cron = "0 0 2 * * *")
+    @SchedulerLock(name = "outboxScheduler")
     public void run() {
         log.info("탈퇴 회원 프로필 사진 파기 스케줄러 실행");
         outboxWorker.execute();

--- a/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeScheduler.java
@@ -3,6 +3,7 @@ package io.wisoft.ignoa_api.user.scheduler;
 import io.wisoft.ignoa_api.user.service.UserPurgeJob;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ public class UserPurgeScheduler {
     private final UserPurgeJob userPurgeJob;
 
     @Scheduled(cron = "0 0 1 * * *")
+    @SchedulerLock(name = "userPurgeScheduler")
     public void purgeExpiredWithdrawals() {
         log.info("탈퇴 회원 개인정보 파기 스케줄러 실행");
         userPurgeJob.execute();


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #40 

## 📝 작업 내용 (Description)

  멀티 인스턴스 환경에서 스케줄러 중복 실행 방지를 위해 ShedLock + Redis를 적용했습니다.

  - ShedLockConfig 구현 (RedisLockProvider)
  - UserPurgeScheduler, OutboxScheduler, AuctionCloseScheduler에 @SchedulerLock 적용

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [ ] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

- 현재 단일 서버로 운영 중이라 실제 문제가 발생하진 않지만, 이중화를 고려한 선제적 개선입니다.
- 추후 Redis 분산 락 직접 구현으로 교체 예정입니다.