### PR TITLE
feat: 상품 API 개편 및 공개 엔드포인트 설정

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
@@ -1,7 +1,7 @@
 package io.wisoft.ignoa_api.auction.scheduler;
 
 
-import io.wisoft.ignoa_api.auction.service.AuctionCloseProcessor;
+import io.wisoft.ignoa_api.auction.service.AuctionCloseJob;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuctionCloseScheduler {
 
-    private final AuctionCloseProcessor auctionCloseProcessor;
+    private final AuctionCloseJob auctionCloseProcessor;
 
     @Scheduled(cron = "0 */5 * * * *")
     @SchedulerLock(name = "auctionCloseScheduler")

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseJob.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AuctionCloseProcessor {
+public class AuctionCloseJob {
 
     private final AuctionCloseService auctionCloseService;
     private final ItemRepository itemRepository;

--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -45,6 +46,7 @@ public class SecurityConfig {
                                 "/api/users/email/duplicate",
                                 "/api/users/nickname/duplicate"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/items", "/api/items/{itemId}", "/api/items/{itemId}/bids").permitAll()
                         .requestMatchers("/ws").permitAll()
                         .anyRequest().authenticated()
                 ).exceptionHandling(exception -> exception

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     ITEM_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 미디어를 찾을 수 없습니다."),
     ITEM_MEDIA_REQUIRED(HttpStatus.BAD_REQUEST, "상품 미디어는 최소 1개 이상이어야 합니다."),
     AUCTION_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 경매입니다."),
+    INVALID_BUY_NOW_PRICE(HttpStatus.BAD_REQUEST, "즉시 구매가는 현재 입찰가보다 낮을 수 없습니다."),
 
     // Bid
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),

--- a/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
@@ -5,8 +5,8 @@ import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemListRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
 import io.wisoft.ignoa_api.item.dto.response.ItemResponse;
-import io.wisoft.ignoa_api.item.dto.response.ItemDetailResponse;
-import io.wisoft.ignoa_api.item.dto.response.ItemSummary;
+import io.wisoft.ignoa_api.item.dto.response.ItemDetail;
+import io.wisoft.ignoa_api.item.dto.response.ItemPreview;
 import io.wisoft.ignoa_api.item.service.ItemService;
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import jakarta.validation.Valid;
@@ -41,34 +41,34 @@ public class ItemController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<SliceResponse<ItemSummary>>> getItems(
+    public ResponseEntity<ApiResponse<SliceResponse<ItemPreview>>> getItems(
             @Valid @ModelAttribute ItemListRequest request,
             @AuthenticationPrincipal Long userId
     ) {
-        SliceResponse<ItemSummary> data = itemService.getItems(userId, request);
-        ApiResponse<SliceResponse<ItemSummary>> response = ApiResponse.of(data, "상품 리스트를 조회했습니다.");
+        SliceResponse<ItemPreview> data = itemService.getItems(userId, request);
+        ApiResponse<SliceResponse<ItemPreview>> response = ApiResponse.of(data, "상품 리스트를 조회했습니다.");
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{itemId}")
-    public ResponseEntity<ApiResponse<ItemDetailResponse>> getItem(
+    public ResponseEntity<ApiResponse<ItemDetail>> getItem(
             @PathVariable Long itemId,
             @AuthenticationPrincipal Long userId
     ) {
-        ItemDetailResponse data = itemService.getItemDetail(itemId, userId);
-        ApiResponse<ItemDetailResponse> response = ApiResponse.of(data, "상품 상세 정보를 조회했습니다.");
+        ItemDetail data = itemService.getItemDetail(itemId, userId);
+        ApiResponse<ItemDetail> response = ApiResponse.of(data, "상품 상세 정보를 조회했습니다.");
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping(value = "/{itemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<ItemDetailResponse>> updateItem(
+    public ResponseEntity<ApiResponse<ItemDetail>> updateItem(
             @PathVariable Long itemId,
             @Valid @RequestPart ItemUpdateRequest request,
             @RequestPart(required = false) List<MultipartFile> files,
             @AuthenticationPrincipal Long userId
     ) {
-        ItemDetailResponse data = itemService.updateItem(itemId, userId, request, files);
-        ApiResponse<ItemDetailResponse> response = ApiResponse.of(data, "상품 정보를 수정했습니다.");
+        ItemDetail data = itemService.updateItem(itemId, userId, request, files);
+        ApiResponse<ItemDetail> response = ApiResponse.of(data, "상품 정보를 수정했습니다.");
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemCreateRequest.java
@@ -22,8 +22,12 @@ public record ItemCreateRequest(
         @Min(value = 0, message = "시작 가격은 0원 이상이어야 합니다")
         Long startPrice,
 
+        @NotNull(message = "즉시 구매가는 필수입니다")
         @Min(value = 0, message = "즉시 구매가는 0원 이상이어야 합니다")
         Long buyNowPrice,
+
+        @NotBlank(message = "브랜드명은 필수입니다")
+        String brand,
 
         @NotNull(message = "경매 종료 시간은 필수입니다")
         @Future(message = "경매 종료 시간은 현재보다 미래여야 합니다")

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemUpdateRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemUpdateRequest.java
@@ -1,6 +1,8 @@
 package io.wisoft.ignoa_api.item.dto.request;
 
+import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,6 +11,10 @@ public record ItemUpdateRequest(
         String title,
         String description,
         String category,
+        String brand,
+        ItemCondition itemCondition,
+        @Min(value = 0, message = "즉시 구매가는 0원 이상이어야 합니다")
+        Long buyNowPrice,
         List<Long> deleteMediaIds,
         @Future(message = "경매 종료 시간은 현재보다 미래여야 합니다")
         LocalDateTime endAt

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemDetail.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemDetail.java
@@ -1,53 +1,65 @@
 package io.wisoft.ignoa_api.item.dto.response;
 
 import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record ItemDetailResponse(
+public record ItemDetail(
         Long itemId,
-        Long sellerId,
-        String sellerNickname,
+        SellerProfile seller,
         String title,
         String description,
         String category,
+        String brand,
+        ItemCondition itemCondition,
         Long startPrice,
         Long currentPrice,
         boolean isTopBidder,
+        boolean isBidder,
+        boolean isSeller,
         ItemStatus status,
         LocalDateTime createdAt,
         LocalDateTime endAt,
         Boolean isWished,
         Integer wishCount,
         Integer bidCount,
+        Long viewCount,
         List<ItemMediaInfo> mediaUrls
 ) {
-    public static ItemDetailResponse of(
+    public static ItemDetail of(
             Item item,
+            SellerProfile seller,
             boolean isTopBidder,
+            boolean isBidder,
+            boolean isSeller,
             List<ItemMediaInfo> mediaUrls,
             int wishCount,
             int bidCount,
             boolean isWished
     ) {
-        return new ItemDetailResponse(
+        return new ItemDetail(
                 item.getId(),
-                item.getSeller().getId(),
-                item.getSeller().getNickname(),
+                seller,
                 item.getTitle(),
                 item.getDescription(),
                 item.getCategory(),
+                item.getBrand(),
+                item.getItemCondition(),
                 item.getStartPrice(),
                 item.getCurrentPrice(),
                 isTopBidder,
+                isBidder,
+                isSeller,
                 item.getStatus(),
                 item.getCreatedAt(),
                 item.getEndAt(),
                 isWished,
                 wishCount,
                 bidCount,
+                item.getViewCount(),
                 mediaUrls
         );
     }

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemPreview.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemPreview.java
@@ -5,25 +5,27 @@ import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 
 import java.time.LocalDateTime;
 
-public record ItemSummary(
+public record ItemPreview(
         Long itemId,
+        String brand,
         String title,
         String mediaUrl,
         Long currentPrice,
         Integer wishCount,
-        Integer bidCount,
+        Long viewCount,
         ItemStatus status,
         LocalDateTime endAt
 ) {
 
-    public static ItemSummary from(Item item, String mediaUrl, int wishCount, int bidCount) {
-        return new ItemSummary(
+    public static ItemPreview from(Item item, String mediaUrl, int wishCount) {
+        return new ItemPreview(
                 item.getId(),
+                item.getBrand(),
                 item.getTitle(),
                 mediaUrl,
                 item.getCurrentPrice(),
                 wishCount,
-                bidCount,
+                item.getViewCount(),
                 item.getStatus(),
                 item.getEndAt()
         );

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/SellerProfile.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/SellerProfile.java
@@ -1,0 +1,29 @@
+package io.wisoft.ignoa_api.item.dto.response;
+
+import io.wisoft.ignoa_api.user.entity.User;
+
+public record SellerProfile(
+        Long sellerId,
+        String nickname,
+        String profileImageUrl,
+        String address
+) {
+    public static SellerProfile from(User user) {
+        return new SellerProfile(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                summarizeAddress(user.getAddress())
+        );
+    }
+
+    private static String summarizeAddress(String address) {
+        if (address == null) return null;
+        String[] parts = address.split(" ");
+        if (parts.length < 2) return address;
+        String city = parts[0]
+                .replace("특별시", "").replace("광역시", "")
+                .replace("특별자치도", "").replace("특별자치시", "").replace("도", "");
+        return city + " " + parts[1];
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -47,8 +47,11 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private Long currentPrice;
 
-    @Column
+    @Column(nullable = false)
     private Long buyNowPrice;
+
+    @Column(nullable = false)
+    private String brand;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -57,9 +60,12 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime endAt;
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     public static Item create(User seller, String title, String description, String category,
                               ItemCondition itemCondition, Long startPrice, Long buyNowPrice,
-                              LocalDateTime endAt) {
+                              String brand, LocalDateTime endAt) {
         return new Item(
                 null,
                 seller,
@@ -71,15 +77,25 @@ public class Item extends BaseEntity {
                 startPrice,
                 startPrice,
                 buyNowPrice,
+                brand,
                 ItemStatus.ACTIVE,
-                endAt
+                endAt,
+                0L
         );
     }
 
-    public void updateInfo(String title, String description, String category, LocalDateTime endAt) {
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void updateInfo(String title, String description, String category, String brand,
+                          ItemCondition itemCondition, Long buyNowPrice, LocalDateTime endAt) {
         if (title != null) this.title = title;
         if (description != null) this.description = description;
         if (category != null) this.category = category;
+        if (brand != null) this.brand = brand;
+        if (itemCondition != null) this.itemCondition = itemCondition;
+        if (buyNowPrice != null) this.buyNowPrice = buyNowPrice;
         if (endAt != null) this.endAt = endAt;
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemService.java
@@ -1,7 +1,7 @@
 package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
-import io.wisoft.ignoa_api.auction.service.AuctionRedisService;
+import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.global.common.SliceResponse;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +54,7 @@ public class ItemService {
                 request.itemCondition(),
                 request.startPrice(),
                 request.buyNowPrice(),
+                request.brand(),
                 request.endAt()
         );
 
@@ -63,18 +65,17 @@ public class ItemService {
         return new ItemResponse(item.getId());
     }
 
-    public SliceResponse<ItemSummary> getItems(Long userId, ItemListRequest request) {
+    public SliceResponse<ItemPreview> getItems(Long userId, ItemListRequest request) {
         Slice<Item> itemSlice = getItemsByView(request, userId, PageRequest.of(request.page(), request.size()));
 
-        List<ItemSummary> itemSummaries = itemSlice.getContent().stream()
-                .map(item -> ItemSummary.from(
+        List<ItemPreview> itemPreviews = itemSlice.getContent().stream()
+                .map(item -> ItemPreview.from(
                         item,
                         itemMediaService.getFirstMediaUrl(item.getId()),
-                        getWishCount(item.getId()),
-                        getBidCount(item.getId())
+                        getWishCount(item.getId())
                 )).toList();
 
-        return SliceResponse.of(itemSummaries, itemSlice.hasNext());
+        return SliceResponse.of(itemPreviews, itemSlice.hasNext());
     }
 
     private Slice<Item> getItemsByView(ItemListRequest request, Long userId, Pageable pageable) {
@@ -99,23 +100,31 @@ public class ItemService {
         return bidRepository.countDistinctBidderByItemId(itemId);
     }
 
-    public ItemDetailResponse getItemDetail(Long itemId, Long userId) {
+    @Transactional
+    public ItemDetail getItemDetail(Long itemId, Long userId) {
         Item item = itemRepository.findByIdWithSeller(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
 
-        boolean isTopBidder = bidRepository.findTopByBidderIdAndItemIdOrderByPriceDesc(userId, itemId)
-                .map(bid -> bid.getPrice().equals(item.getCurrentPrice()))
-                .orElse(false);
+        item.increaseViewCount();
+
+        SellerProfile sellerInfo = SellerProfile.from(item.getSeller());
+
+        Optional<Bid> topBid = userId != null
+                ? bidRepository.findTopByBidderIdAndItemIdOrderByPriceDesc(userId, itemId)
+                : Optional.empty();
+        boolean isBidder = topBid.isPresent();
+        boolean isTopBidder = topBid.map(bid -> bid.getPrice().equals(item.getCurrentPrice())).orElse(false);
+        boolean isSeller = userId != null && item.isSeller(userId);
         List<ItemMediaInfo> mediaUrls = itemMediaService.getMediaInfoByItemId(itemId);
         int wishCount = getWishCount(itemId);
         int bidCount = getBidCount(itemId);
-        boolean isWished = wishRepository.existsByUserIdAndItemId(userId, itemId);
+        boolean isWished = userId != null && wishRepository.existsByUserIdAndItemId(userId, itemId);
 
-        return ItemDetailResponse.of(item, isTopBidder, mediaUrls, wishCount, bidCount, isWished);
+        return ItemDetail.of(item, sellerInfo, isTopBidder, isBidder, isSeller, mediaUrls, wishCount, bidCount, isWished);
     }
 
     @Transactional
-    public ItemDetailResponse updateItem(Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files) {
+    public ItemDetail updateItem(Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files) {
         Item item = itemRepository.findByIdWithSeller(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
 
@@ -127,7 +136,12 @@ public class ItemService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        item.updateInfo(request.title(), request.description(), request.category(), request.endAt());
+        if (request.buyNowPrice() != null && request.buyNowPrice() < item.getCurrentPrice()) {
+            throw new BusinessException(ErrorCode.INVALID_BUY_NOW_PRICE);
+        }
+
+        item.updateInfo(request.title(), request.description(), request.category(), request.brand(),
+                request.itemCondition(), request.buyNowPrice(), request.endAt());
 
         if (request.deleteMediaIds() != null && !request.deleteMediaIds().isEmpty()) {
             itemMediaService.validateMinimumMediaCount(itemId, request.deleteMediaIds(), files);

--- a/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
@@ -2,7 +2,7 @@ package io.wisoft.ignoa_api.user.controller;
 
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import io.wisoft.ignoa_api.user.dto.request.UpdateUserRequest;
-import io.wisoft.ignoa_api.user.dto.response.UserMeResponse;
+import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.service.UserCommandService;
 import io.wisoft.ignoa_api.user.service.UserFacade;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
@@ -43,19 +43,19 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserMeResponse>> getMe(@AuthenticationPrincipal Long userId) {
-        UserMeResponse data = userQueryService.getMe(userId);
-        ApiResponse<UserMeResponse> response = ApiResponse.of(data, "마이페이지 조회에 성공했습니다.");
+    public ResponseEntity<ApiResponse<MyProfile>> getMe(@AuthenticationPrincipal Long userId) {
+        MyProfile data = userQueryService.getMe(userId);
+        ApiResponse<MyProfile> response = ApiResponse.of(data, "마이페이지 조회에 성공했습니다.");
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<UserMeResponse>> updateProfileImage(
+    public ResponseEntity<ApiResponse<MyProfile>> updateProfileImage(
             @AuthenticationPrincipal Long userId,
             @RequestPart MultipartFile image
     ) {
-        UserMeResponse data = userFacade.updateProfileImage(userId, image);
-        ApiResponse<UserMeResponse> response = ApiResponse.of(data, "프로필 사진이 변경되었습니다.");
+        MyProfile data = userFacade.updateProfileImage(userId, image);
+        ApiResponse<MyProfile> response = ApiResponse.of(data, "프로필 사진이 변경되었습니다.");
         return ResponseEntity.ok(response);
     }
 
@@ -67,12 +67,12 @@ public class UserController {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UserMeResponse>> updateProfile(
+    public ResponseEntity<ApiResponse<MyProfile>> updateProfile(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody UpdateUserRequest request
     ) {
-        UserMeResponse data = userCommandService.updateProfile(userId, request);
-        ApiResponse<UserMeResponse> response = ApiResponse.of(data, "유저 정보가 수정되었습니다.");
+        MyProfile data = userCommandService.updateProfile(userId, request);
+        ApiResponse<MyProfile> response = ApiResponse.of(data, "유저 정보가 수정되었습니다.");
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/user/dto/response/MyProfile.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/dto/response/MyProfile.java
@@ -2,14 +2,14 @@ package io.wisoft.ignoa_api.user.dto.response;
 
 import io.wisoft.ignoa_api.user.entity.User;
 
-public record UserMeResponse(
+public record MyProfile(
         Long userId,
         String email,
         String nickname,
         String address,
         String profileImageUrl
 ) {
-    public static UserMeResponse from(User user) {
-        return new UserMeResponse(user.getId(), user.getEmail(), user.getNickname(), user.getAddress(), user.getProfileImageUrl());
+    public static MyProfile from(User user) {
+        return new MyProfile(user.getId(), user.getEmail(), user.getNickname(), user.getAddress(), user.getProfileImageUrl());
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
@@ -1,12 +1,10 @@
 package io.wisoft.ignoa_api.user.repository;
 
 import io.wisoft.ignoa_api.user.entity.User;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserCommandService.java
@@ -7,7 +7,7 @@ import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.user.dto.request.UpdateUserRequest;
-import io.wisoft.ignoa_api.user.dto.response.UserMeResponse;
+import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.event.ProfileImageDeletedEvent;
 import io.wisoft.ignoa_api.user.repository.UserRepository;
@@ -54,7 +54,7 @@ public class UserCommandService {
         eventPublisher.publishEvent(new ProfileImageDeletedEvent(profileImageUrl));
     }
 
-    public UserMeResponse updateProfile(Long userId, UpdateUserRequest request) {
+    public MyProfile updateProfile(Long userId, UpdateUserRequest request) {
         User user = userQueryService.findById(userId);
 
         if (request.nickname() != null && userRepository.existsByNickname(request.nickname())) {
@@ -63,7 +63,7 @@ public class UserCommandService {
 
         user.updateProfile(request.nickname(), request.address());
 
-        return UserMeResponse.from(user);
+        return MyProfile.from(user);
     }
 
     public void withdraw(Long userId) {

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
@@ -3,7 +3,7 @@ package io.wisoft.ignoa_api.user.service;
 import io.wisoft.ignoa_api.auth.service.RefreshTokenService;
 import io.wisoft.ignoa_api.auth.service.TokenBlacklistService;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
-import io.wisoft.ignoa_api.user.dto.response.UserMeResponse;
+import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ public class UserFacade {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
-    public UserMeResponse updateProfileImage(Long userId, MultipartFile image) {
+    public MyProfile updateProfileImage(Long userId, MultipartFile image) {
         User user = userQueryService.findById(userId);
 
         String oldImageUrl = user.getProfileImageUrl();
@@ -29,7 +29,7 @@ public class UserFacade {
         user.updateProfileImage(newImageUrl);
         userCommandService.saveProfileImage(user, oldImageUrl);
 
-        return UserMeResponse.from(user);
+        return MyProfile.from(user);
     }
 
     public void deleteMe(Long userId, String accessToken, String refreshToken) {

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserQueryService.java
@@ -2,7 +2,7 @@ package io.wisoft.ignoa_api.user.service;
 
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
-import io.wisoft.ignoa_api.user.dto.response.UserMeResponse;
+import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +39,9 @@ public class UserQueryService {
         }
     }
 
-    public UserMeResponse getMe(Long userId) {
-        return UserMeResponse.from(findById(userId));
+    public MyProfile getMe(Long userId) {
+        User user = findById(userId);
+        return MyProfile.from(user);
     }
 
     public List<User> findPurgeTargets(LocalDateTime startDateTime, LocalDateTime endDateTime, Long lastId, int batchSize) {

--- a/src/main/java/io/wisoft/ignoa_api/wish/controller/WishController.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/controller/WishController.java
@@ -3,7 +3,7 @@ package io.wisoft.ignoa_api.wish.controller;
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import io.wisoft.ignoa_api.global.common.SliceResponse;
 import io.wisoft.ignoa_api.wish.dto.request.WishListRequest;
-import io.wisoft.ignoa_api.wish.dto.response.WishSummary;
+import io.wisoft.ignoa_api.wish.dto.response.WishPreview;
 import io.wisoft.ignoa_api.wish.service.WishService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,12 +40,12 @@ public class WishController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<SliceResponse<WishSummary>>> getWishes(
+    public ResponseEntity<ApiResponse<SliceResponse<WishPreview>>> getWishes(
             @Valid @ModelAttribute WishListRequest request,
             @AuthenticationPrincipal Long userId
     ) {
-        SliceResponse<WishSummary> data = wishService.getWishes(userId, request);
-        ApiResponse<SliceResponse<WishSummary>> response = ApiResponse.of(data, "찜 목록을 조회했습니다.");
+        SliceResponse<WishPreview> data = wishService.getWishes(userId, request);
+        ApiResponse<SliceResponse<WishPreview>> response = ApiResponse.of(data, "찜 목록을 조회했습니다.");
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/wish/dto/response/WishPreview.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/dto/response/WishPreview.java
@@ -4,23 +4,25 @@ import io.wisoft.ignoa_api.wish.entity.Wish;
 
 import java.time.LocalDateTime;
 
-public record WishSummary(
+public record WishPreview(
         Long wishId,
         Long itemId,
         String title,
         String category,
         Long currentPrice,
+        Integer wishCount,
         LocalDateTime endAt,
         String mediaUrl,
         LocalDateTime wishedAt
 ) {
-    public static WishSummary from(Wish wish, String mediaUrl) {
-        return new WishSummary(
+    public static WishPreview from(Wish wish, String mediaUrl, int wishCount) {
+        return new WishPreview(
                 wish.getId(),
                 wish.getItem().getId(),
                 wish.getItem().getTitle(),
                 wish.getItem().getCategory(),
                 wish.getItem().getCurrentPrice(),
+                wishCount,
                 wish.getItem().getEndAt(),
                 mediaUrl,
                 wish.getCreatedAt()

--- a/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
@@ -7,7 +7,7 @@ import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemMediaService;
 import io.wisoft.ignoa_api.wish.dto.request.WishListRequest;
-import io.wisoft.ignoa_api.wish.dto.response.WishSummary;
+import io.wisoft.ignoa_api.wish.dto.response.WishPreview;
 import io.wisoft.ignoa_api.wish.entity.Wish;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -53,11 +53,14 @@ public class WishService {
         wishRepository.delete(wish);
     }
 
-    public SliceResponse<WishSummary> getWishes(Long userId, WishListRequest request) {
+    public SliceResponse<WishPreview> getWishes(Long userId, WishListRequest request) {
         Slice<Wish> wishSlice = wishRepository.findByUserIdWithItem(userId, PageRequest.of(request.page(), request.size()));
 
-        List<WishSummary> wishSummaries = wishSlice.getContent().stream()
-                .map(wish -> WishSummary.from(wish, itemMediaService.getFirstMediaUrl(wish.getItem().getId())))
+        List<WishPreview> wishSummaries = wishSlice.getContent().stream()
+                .map(wish -> WishPreview.from(
+                        wish,
+                        itemMediaService.getFirstMediaUrl(wish.getItem().getId()),
+                        wishRepository.countByItemId(wish.getItem().getId())))
                 .toList();
 
         return SliceResponse.of(wishSummaries, wishSlice.hasNext());


### PR DESCRIPTION
## 📝 작업 내용 (Description)  

- Item 엔티티에 `brand`, `viewCount` 필드 추가
- `ItemDetailResponse` → `ItemDetail`, `ItemSummary` → `ItemPreview`, `UserMeResponse` → `MyProfile` 네이밍 정리
- `ItemDetail`에 `SellerProfile` 중첩 DTO 적용 및 주소 시/구 단위 파싱
- `ItemDetail`에 `isSeller`, `isBidder` 추가로 3단계 입찰 상태 구분 지원
- `ItemUpdateRequest`에 `itemCondition`, `buyNowPrice` 추가 및 buyNowPrice 검증 로직 적용
- `WishSummary` → `WishPreview` 네이밍 정리 및 `wishCount` 추가
- `AuctionCloseProcessor` → `AuctionCloseJob` 네이밍 정리
- `SecurityConfig` 공개 API 설정 (상품 목록/상세/입찰 이력 비로그인 허용)

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다
