### PR TITLE
refactor: 마이페이지 상품/입찰 목록 조회 API 분리

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -28,9 +28,9 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class BidService {
 
-    private final ApplicationEventPublisher eventPublisher;
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
 
     @Transactional

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -84,10 +84,6 @@ public class Item extends BaseEntity {
         );
     }
 
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
-
     public void update(String title, String description, String category, String brand,
                        ItemCondition itemCondition, Long buyNowPrice, LocalDateTime endAt) {
         if (title != null) this.title = title;

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -38,18 +38,15 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Slice<Item> findLatestItems(@Param("category") String category, Pageable pageable);
 
     @Query("SELECT i FROM Item i " +
-            "WHERE i.seller.id = :userId " +
-            "AND (:category IS NULL OR i.category = :category) " +
+            "WHERE i.seller.id = :sellerId " +
             "ORDER BY i.createdAt DESC")
-    Slice<Item> findMyItems(@Param("category") String category, @Param("userId") Long userId, Pageable pageable);
+    List<Item> findItemsBySellerId(@Param("sellerId") Long sellerId);
 
     @Query("SELECT DISTINCT i FROM Item i " +
             "JOIN Bid b ON b.item = i " +
-            "WHERE b.bidder.id = :userId " +
-            "AND i.status = 'ACTIVE' " +
-            "AND (:category IS NULL OR i.category = :category) " +
+            "WHERE b.bidder.id = :bidderId " +
             "ORDER BY i.createdAt DESC")
-    Slice<Item> findMyBidItems(@Param("category") String category, @Param("userId") Long userId, Pageable pageable);
+    List<Item> findItemsByBidderId(@Param("bidderId") Long bidderId);
 
     @Query("SELECT i FROM Item i " +
             "JOIN FETCH i.seller " +

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
@@ -70,6 +70,24 @@ public class ItemQueryService {
         };
     }
 
+    public List<ItemPreview> getMyItems(Long userId) {
+        return itemRepository.findItemsBySellerId(userId).stream()
+                .map(item -> ItemPreview.from(
+                        item,
+                        itemMediaService.getFirstMediaUrl(item.getId()),
+                        getWishCount(item.getId())
+                )).toList();
+    }
+
+    public List<ItemPreview> getMyBids(Long userId) {
+        return itemRepository.findItemsByBidderId(userId).stream()
+                .map(item -> ItemPreview.from(
+                        item,
+                        itemMediaService.getFirstMediaUrl(item.getId()),
+                        getWishCount(item.getId())
+                )).toList();
+    }
+
     public Item getItemWithSeller(Long itemId) {
         return itemRepository.findByIdWithSeller(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));

--- a/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.user.controller;
 
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import io.wisoft.ignoa_api.item.dto.response.ItemPreview;
+import io.wisoft.ignoa_api.item.service.ItemQueryService;
 import io.wisoft.ignoa_api.user.dto.request.UpdateUserRequest;
 import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.service.UserCommandService;
@@ -18,6 +19,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 import static io.wisoft.ignoa_api.global.common.CookieUtils.createClearRefreshTokenCookie;
 
 @RestController
@@ -28,6 +31,8 @@ public class UserController {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
     private final UserFacade userFacade;
+
+    private final ItemQueryService itemQueryService;
 
     @GetMapping("/email/duplicate")
     public ResponseEntity<ApiResponse<Void>> checkDuplicateEmail(@RequestParam String email) {
@@ -90,5 +95,23 @@ public class UserController {
         response.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
 
         return ResponseEntity.ok(ApiResponse.of(null, "회원 탈퇴가 되었습니다."));
+    }
+
+    @GetMapping("/me/items")
+    public ResponseEntity<ApiResponse<List<ItemPreview>>> getMyItems(
+        @AuthenticationPrincipal Long userId
+    ) {
+        List<ItemPreview> data = itemQueryService.getMyItems(userId);
+        ApiResponse<List<ItemPreview>> response = ApiResponse.of(data, "내 상품 목록을 조회했습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me/bids")
+    public ResponseEntity<ApiResponse<List<ItemPreview>>> getMyBids(
+        @AuthenticationPrincipal Long userId
+    ) {
+        List<ItemPreview> data = itemQueryService.getMyBids(userId);
+        ApiResponse<List<ItemPreview>> response = ApiResponse.of(data, "내 입찰 목록을 조회했습니다.");
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #48 

## 📝 작업 내용 (Description)

 > 기존 `GET /api/items` view 타입 기반 조회에서 마이페이지 전용 엔드포인트로 분리

  - `GET /api/users/me/items` — 내가 등록한 상품 목록
  - `GET /api/users/me/bids` — 내가 입찰한 상품 목록

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다
