### PR TITLE
feat: 즉시 구매 구현

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/event/AuctionClosedEvent.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/event/AuctionClosedEvent.java
@@ -1,6 +1,6 @@
 package io.wisoft.ignoa_api.auction.event;
 
-public record AuctionCanceledEvent(
+public record AuctionClosedEvent(
         Long itemId
 ) {
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionExpiredListener.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionExpiredListener.java
@@ -27,7 +27,7 @@ public class AuctionExpiredListener implements MessageListener {
             long itemId = Long.parseLong(expiredKey.substring(AUCTION_KEY_PREFIX.length()));
             auctionCloseService.closeAuction(itemId);
         } catch (Exception e) {
-            log.error("경매 마감 처리 실패 expiredKey={}", message.toString(), e);
+            log.error("경매 마감 처리 실패 expiredKey={}", message, e);
         }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionTtlListener.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionTtlListener.java
@@ -1,8 +1,8 @@
 package io.wisoft.ignoa_api.auction.listener;
 
+import io.wisoft.ignoa_api.auction.event.AuctionClosedEvent;
 import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
-import io.wisoft.ignoa_api.auction.service.AuctionRedisService;
-import io.wisoft.ignoa_api.auction.event.AuctionCanceledEvent;
+import io.wisoft.ignoa_api.auction.service.AuctionTtlService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -10,9 +10,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class AuctionRegistrationListener {
+public class AuctionTtlListener {
 
-    private final AuctionRedisService auctionRedisService;
+    private final AuctionTtlService auctionRedisService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onAuctionRegistered(AuctionRegisteredEvent event) {
@@ -20,7 +20,7 @@ public class AuctionRegistrationListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onItemDeleted(AuctionCanceledEvent event) {
+    public void onAuctionClosed(AuctionClosedEvent event) {
         auctionRedisService.deleteTtl(event.itemId());
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
@@ -1,5 +1,6 @@
-package io.wisoft.ignoa_api.auction.service;
+package io.wisoft.ignoa_api.auction.scheduler;
 
+import io.wisoft.ignoa_api.auction.service.AuctionCloseService;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
@@ -20,10 +21,9 @@ public class AuctionCloseJob {
     private final AuctionCloseService auctionCloseService;
     private final ItemRepository itemRepository;
 
-    public void closeExpiredBids() {
-        List<Item> expiredItems = itemRepository.findAllByStatusAndEndAtBefore(
-                ItemStatus.ACTIVE, LocalDateTime.now()
-        );
+    public void closeExpiredAuctions() {
+        List<Item> expiredItems = itemRepository
+                .findAllByStatusAndEndAtBefore(ItemStatus.ACTIVE, LocalDateTime.now());
 
         for (Item item : expiredItems) {
             try {

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
@@ -1,7 +1,6 @@
 package io.wisoft.ignoa_api.auction.scheduler;
 
 
-import io.wisoft.ignoa_api.auction.service.AuctionCloseJob;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -13,12 +12,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuctionCloseScheduler {
 
-    private final AuctionCloseJob auctionCloseProcessor;
+    private final AuctionCloseJob auctionCloseJob;
 
     @Scheduled(cron = "0 */5 * * * *")
     @SchedulerLock(name = "auctionCloseScheduler")
-    public void closeExpiredBids() {
+    public void closeExpiredAuctions() {
         log.info("경매 마감 스케줄러 실행");
-        auctionCloseProcessor.closeExpiredBids();
+        auctionCloseJob.closeExpiredAuctions();
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -2,11 +2,12 @@ package io.wisoft.ignoa_api.auction.service;
 
 import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.bid.service.BidService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,28 +21,32 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AuctionCloseService {
 
+    private final BidService bidService;
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void closeAuction(Long itemId) {
-        Item lockedItem = itemRepository.findByIdWithLock(itemId)
+        Item item = itemRepository.findByIdWithLock(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
 
-        if (lockedItem.getStatus() != ItemStatus.ACTIVE) {
-            log.info("[중복 마감 방지] 이미 마감된 경매 itemId={} status={}", itemId, lockedItem.getStatus());
+        if (!item.isActive()) {
+            log.info("[중복 마감 방지] 이미 마감된 경매 itemId={} status={}", itemId, item.getStatus());
             return;
         }
 
-        Optional<Bid> highestBid = bidRepository.findTopByItemIdOrderByPriceDesc(itemId);
+        Optional<Bid> bid = bidRepository.findTopByItemIdOrderByPriceDesc(itemId);
 
-        if (highestBid.isEmpty()) {
-            lockedItem.closeAsNoBid();
+        if (bid.isEmpty()) {
+            item.closeWithoutBid();
             return;
         }
 
-        Bid winningBid = highestBid.get();
-        lockedItem.closeWithWinner(winningBid.getBidder());
-        winningBid.closeAsWon();
+        bidService.closeBids(itemId);
+        Bid topBid = bid.get();
+        topBid.closeAsWon();
+
+        User winner = topBid.getBidder();
+        item.closeWithWinner(winner);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionTtlService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionTtlService.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AuctionRedisService {
+public class AuctionTtlService {
 
     private static final String AUCTION_KEY_PREFIX = "auction:";
     private final StringRedisTemplate stringRedisTemplate;

--- a/src/main/java/io/wisoft/ignoa_api/bid/entity/Bid.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/entity/Bid.java
@@ -39,4 +39,8 @@ public class Bid extends BaseEntity {
     public void closeAsWon() {
         this.status = BidStatus.WON;
     }
+
+    public void closeAsLost() {
+        this.status = BidStatus.LOST;
+    }
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/entity/BidStatus.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/entity/BidStatus.java
@@ -2,5 +2,6 @@ package io.wisoft.ignoa_api.bid.entity;
 
 public enum BidStatus {
     ACTIVE,
-    WON
+    WON,
+    LOST
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BidRepository extends JpaRepository<Bid, Long> {
@@ -25,4 +26,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
     @Query("SELECT COUNT(b) > 0 FROM Bid b WHERE b.bidder.id = :userId AND b.item.status = 'ACTIVE'")
     boolean existsByBidderIdAndItemActive(@Param("userId") Long userId);
+
+    List<Bid> findByItemId(Long itemId);
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -53,7 +53,7 @@ public class BidService {
             throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
         }
 
-        item.raisePriceTo(request.price());
+        item.raiseBidPrice(request.price());
 
         Bid bid = Bid.place(item, bidder, request.price());
         bidRepository.save(bid);
@@ -63,12 +63,19 @@ public class BidService {
         return BidResponse.from(bid);
     }
 
+    @Transactional
+    public void closeBids(Long itemId) {
+        bidRepository.findByItemId(itemId)
+                .forEach(Bid::closeAsLost);
+    }
+
     public SliceResponse<BidSummary> getBids(Long itemId, BidListRequest request) {
         if (!itemRepository.existsById(itemId)) {
             throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
         }
 
-        Slice<Bid> bidSlice = bidRepository.findByItemIdWithBidder(itemId, PageRequest.of(request.page(), request.size()));
+        Slice<Bid> bidSlice = bidRepository.findByItemIdWithBidder(
+                itemId, PageRequest.of(request.page(), request.size()));
 
         List<BidSummary> bidSummaries = bidSlice.getContent().stream()
                 .map(BidSummary::from)

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),
     AUCTION_CLOSED(HttpStatus.BAD_REQUEST, "종료된 경매에는 입찰할 수 없습니다."),
     SELF_BID_NOT_ALLOWED(HttpStatus.FORBIDDEN, "본인 상품에는 입찰할 수 없습니다."),
+    SELF_BUY_NOT_ALLOWED(HttpStatus.FORBIDDEN, "본인 상품은 구매할 수 없습니다."),
 
     // Storage
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
@@ -4,6 +4,7 @@ import io.wisoft.ignoa_api.global.common.SliceResponse;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemPreviewRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
+import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
 import io.wisoft.ignoa_api.item.dto.response.ItemIdResponse;
 import io.wisoft.ignoa_api.item.dto.response.ItemDetail;
 import io.wisoft.ignoa_api.item.dto.response.ItemPreview;
@@ -31,17 +32,6 @@ public class ItemController {
     private final ItemQueryService itemQueryService;
     private final ItemCommandService itemCommandService;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<ItemIdResponse>> createItem(
-            @Valid @RequestPart ItemCreateRequest request,
-            @RequestPart @NotEmpty(message = "상품 이미지는 최소 1개 이상이어야 합니다.") List<MultipartFile> files,
-            @AuthenticationPrincipal Long sellerId
-    ) {
-        ItemIdResponse data = itemCommandService.createItem(sellerId, request, files);
-        ApiResponse<ItemIdResponse> response = ApiResponse.of(data, "상품이 등록되었습니다.");
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-
     @GetMapping
     public ResponseEntity<ApiResponse<SliceResponse<ItemPreview>>> getItems(
             @Valid @ModelAttribute ItemPreviewRequest request
@@ -59,6 +49,17 @@ public class ItemController {
         ItemDetail data = itemQueryService.getItem(itemId, userId);
         ApiResponse<ItemDetail> response = ApiResponse.of(data, "상품 상세 정보를 조회했습니다.");
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ItemIdResponse>> createItem(
+            @Valid @RequestPart ItemCreateRequest request,
+            @RequestPart @NotEmpty(message = "상품 이미지는 최소 1개 이상이어야 합니다.") List<MultipartFile> files,
+            @AuthenticationPrincipal Long sellerId
+    ) {
+        ItemIdResponse data = itemCommandService.createItem(sellerId, request, files);
+        ApiResponse<ItemIdResponse> response = ApiResponse.of(data, "상품이 등록되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PatchMapping(value = "/{itemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -80,6 +81,16 @@ public class ItemController {
     ) {
         ItemIdResponse data = itemCommandService.deleteItem(itemId, userId);
         ApiResponse<ItemIdResponse> response = ApiResponse.of(data, "상품을 삭제했습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{itemId}/buy-now")
+    public ResponseEntity<ApiResponse<BuyNowResponse>> buyNowItem(
+            @PathVariable Long itemId,
+            @AuthenticationPrincipal Long buyerId
+    ) {
+        BuyNowResponse data = itemCommandService.buyNowItem(itemId, buyerId);
+        ApiResponse<BuyNowResponse> response = ApiResponse.of(data, "상품을 즉시 구매하였습니다.");
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/BuyNowResponse.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/BuyNowResponse.java
@@ -1,0 +1,11 @@
+package io.wisoft.ignoa_api.item.dto.response;
+
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+
+public record BuyNowResponse(
+        Long itemId,
+        Long buyerId,
+        Long price,
+        ItemStatus status
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemDetail.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemDetail.java
@@ -17,6 +17,7 @@ public record ItemDetail(
         ItemCondition itemCondition,
         Long startPrice,
         Long currentPrice,
+        Long buyNowPrice,
         boolean isTopBidder,
         boolean isBidder,
         boolean isSeller,
@@ -27,7 +28,7 @@ public record ItemDetail(
         Integer wishCount,
         Integer bidCount,
         Long viewCount,
-        List<ItemMediaUrl> mediaUrls
+        List<ItemMediaResponse> mediaUrls
 ) {
     public static ItemDetail of(
             Item item,
@@ -35,7 +36,7 @@ public record ItemDetail(
             boolean isTopBidder,
             boolean isBidder,
             boolean isSeller,
-            List<ItemMediaUrl> mediaUrls,
+            List<ItemMediaResponse> mediaUrls,
             int wishCount,
             int bidCount,
             boolean isWished
@@ -50,6 +51,7 @@ public record ItemDetail(
                 item.getItemCondition(),
                 item.getStartPrice(),
                 item.getCurrentPrice(),
+                item.getBuyNowPrice(),
                 isTopBidder,
                 isBidder,
                 isSeller,

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemMediaResponse.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemMediaResponse.java
@@ -1,7 +1,7 @@
 package io.wisoft.ignoa_api.item.dto.response;
 
-public record ItemMediaUrl(
-        Long id,
+public record ItemMediaResponse(
+        Long itemMediaId,
         String url
 ) {
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -95,8 +95,12 @@ public class Item extends BaseEntity {
         if (endAt != null) this.endAt = endAt;
     }
 
-    public void raisePriceTo(Long newPrice) {
+    public void raiseBidPrice(Long newPrice) {
         this.currentPrice = newPrice;
+    }
+
+    public boolean isSeller(Long userId) {
+        return this.seller.getId().equals(userId);
     }
 
     public boolean isActive() {
@@ -104,33 +108,34 @@ public class Item extends BaseEntity {
                 && this.endAt.isAfter(LocalDateTime.now());
     }
 
-    public boolean isSeller(Long userId) {
-        return this.seller.getId().equals(userId);
+    public boolean isClosed() {
+        return this.status != ItemStatus.ACTIVE;
+    }
+
+    public boolean isCompleted() {
+        return this.status == ItemStatus.BID_CLOSED
+                || this.status == ItemStatus.BUY_NOW_CLOSED;
     }
 
     public boolean isValidBidPrice(Long bidPrice) {
         return this.currentPrice < bidPrice;
     }
 
-    public void closeAsNoBid() {
+    public boolean isValidBuyNowPrice(Long buyNowPrice) {
+        return buyNowPrice == null || buyNowPrice > this.currentPrice;
+    }
+
+    public void buyNow(User winner) {
+        this.winner = winner;
+        this.status = ItemStatus.BUY_NOW_CLOSED;
+    }
+
+    public void closeWithoutBid() {
         this.status = ItemStatus.NO_BID_CLOSED;
     }
 
     public void closeWithWinner(User winner) {
         this.winner = winner;
         this.status = ItemStatus.BID_CLOSED;
-    }
-
-    public boolean isClosed() {
-        return this.status != ItemStatus.ACTIVE;
-    }
-
-    public boolean isValidBuyNowPrice(Long buyNowPrice) {
-        return buyNowPrice == null || buyNowPrice > this.currentPrice;
-    }
-
-    public boolean isCompleted() {
-        return this.status == ItemStatus.BID_CLOSED
-                || this.status == ItemStatus.BUY_NOW_CLOSED;
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemMediaRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemMediaRepository.java
@@ -1,6 +1,6 @@
 package io.wisoft.ignoa_api.item.repository;
 
-import io.wisoft.ignoa_api.item.dto.response.ItemMediaUrl;
+import io.wisoft.ignoa_api.item.dto.response.ItemMediaResponse;
 import io.wisoft.ignoa_api.item.entity.ItemMedia;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,11 +13,7 @@ public interface ItemMediaRepository extends JpaRepository<ItemMedia, Long> {
 
     Optional<ItemMedia> findFirstByItemIdOrderByIdAsc(Long itemId);
 
-    @Query("SELECT new io.wisoft.ignoa_api.item.dto.response.ItemMediaUrl(im.id, im.mediaUrl) " +
-            "FROM ItemMedia im " +
-            "WHERE im.item.id = :itemId " +
-            "ORDER BY im.id ASC")
-    List<ItemMediaUrl> findMediaInfoByItemId(@Param("itemId") Long itemId);
+    List<ItemMedia> findAllByItemIdOrderByIdAsc(Long itemId);
 
     void deleteAllByItemIdAndIdIn(Long itemId, List<Long> ids);
 

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -1,15 +1,17 @@
 package io.wisoft.ignoa_api.item.service;
 
+import io.wisoft.ignoa_api.auction.event.AuctionClosedEvent;
 import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.bid.service.BidService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
+import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
 import io.wisoft.ignoa_api.item.dto.response.ItemDetail;
 import io.wisoft.ignoa_api.item.dto.response.ItemIdResponse;
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.auction.event.AuctionCanceledEvent;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
@@ -27,11 +29,13 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ItemCommandService {
 
     private final ItemMediaService itemMediaService;
     private final ItemQueryService itemQueryService;
     private final UserQueryService userQueryService;
+    private final BidService bidService;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -39,7 +43,6 @@ public class ItemCommandService {
     private final WishRepository wishRepository;
     private final BidRepository bidRepository;
 
-    @Transactional
     public ItemIdResponse createItem(
             Long sellerId, ItemCreateRequest request, List<MultipartFile> files
     ) {
@@ -64,7 +67,6 @@ public class ItemCommandService {
         return new ItemIdResponse(item.getId());
     }
 
-    @Transactional
     public ItemDetail updateItem(
             Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files
     ) {
@@ -106,7 +108,6 @@ public class ItemCommandService {
         return itemQueryService.getItem(itemId, userId);
     }
 
-    @Transactional
     public ItemIdResponse deleteItem(Long itemId, Long userId) {
         Item item = itemQueryService.getItemWithSeller(itemId);
 
@@ -123,8 +124,28 @@ public class ItemCommandService {
         itemMediaService.deleteAllByItemId(itemId);
         itemRepository.delete(item);
 
-        eventPublisher.publishEvent(new AuctionCanceledEvent(itemId));
+        eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
         return new ItemIdResponse(item.getId());
+    }
+
+    public BuyNowResponse buyNowItem(Long itemId, Long buyerId) {
+        Item item = itemRepository.findByIdWithLock(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        User user = userQueryService.findById(buyerId);
+
+        if (!item.isActive()) {
+            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
+        }
+
+        if (item.isSeller(buyerId)) {
+            throw new BusinessException(ErrorCode.SELF_BUY_NOT_ALLOWED);
+        }
+
+        item.buyNow(user);
+        bidService.closeBids(itemId);
+        eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
+
+        return new BuyNowResponse(itemId, buyerId, item.getBuyNowPrice(), item.getStatus());
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
@@ -4,7 +4,7 @@ import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
 import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
-import io.wisoft.ignoa_api.item.dto.response.ItemMediaUrl;
+import io.wisoft.ignoa_api.item.dto.response.ItemMediaResponse;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.ItemMedia;
 import io.wisoft.ignoa_api.item.entity.enums.ItemMediaType;
@@ -33,8 +33,11 @@ public class ItemMediaService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_MEDIA_NOT_FOUND));
     }
 
-    public List<ItemMediaUrl> getMediaInfoByItemId(Long itemId) {
-        return itemMediaRepository.findMediaInfoByItemId(itemId);
+    public List<ItemMediaResponse> getMediaUrlByItemId(Long itemId) {
+        return itemMediaRepository.findAllByItemIdOrderByIdAsc(itemId).stream()
+                .map(itemMedia ->
+                        new ItemMediaResponse(itemMedia.getId(), itemMedia.getMediaUrl()))
+                .toList();
     }
 
     public void validateMinimumMediaCount(Long itemId, List<Long> mediaIds, List<MultipartFile> files) {

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
@@ -53,7 +53,7 @@ public class ItemQueryService {
         boolean isBidder = topBid.isPresent();
         boolean isTopBidder = topBid.map(bid -> bid.getPrice().equals(item.getCurrentPrice())).orElse(false);
         boolean isSeller = userId != null && item.isSeller(userId);
-        List<ItemMediaUrl> mediaUrls = itemMediaService.getMediaInfoByItemId(itemId);
+        List<ItemMediaResponse> mediaUrls = itemMediaService.getMediaUrlByItemId(itemId);
         int wishCount = getWishCount(itemId);
         int bidCount = getBidCount(itemId);
         boolean isWished = userId != null && wishRepository.existsByUserIdAndItemId(userId, itemId);


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #50 

## 📝 작업 내용 (Description)

  **1. 입찰/경매 상태 전이 정리**
  - `BidStatus`에 `LOST` 추가
  - 경매 마감 시 낙찰자 `WON`, 나머지 전체 `LOST` 처리
  - `BidService.closeBids()` 추가

  **2. 즉시구매 구현**
  - `POST /api/items/{itemId}/buy-now` API 추가
  - 즉시구매 시 기존 입찰 전체 `LOST` 처리
  - `ItemDetail` 응답에 `buyNowPrice` 추가

  **3. Auction 도메인 네이밍 정리**
  - `AuctionRedisService` → `AuctionTtlService`
  - `AuctionRegistrationListener` → `AuctionTtlListener`
  - `AuctionCloseJob` → `scheduler` 패키지로 이동
  - `AuctionCanceledEvent` 제거 → `AuctionClosedEvent`로 통일
  - Item 도메인 메서드 네이밍 정리 (`closeWithWinner`, `closeAsNoBid` 등)

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

## 💬 추가 코멘트 (Additional Comments)

  `bids.status` 컬럼 길이 변경 필요 (LOST 추가로 인한 DB 마이그레이션)
  ```sql
  ALTER TABLE bids MODIFY COLUMN status VARCHAR(10) NOT NULL;