### PR TITLE
refactor: 상품 삭제 정책 수정

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -28,4 +28,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     boolean existsByBidderIdAndItemActive(@Param("userId") Long userId);
 
     List<Bid> findByItemId(Long itemId);
+
+    boolean existsByItemId(Long itemId);
 }

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
     ITEM_MEDIA_REQUIRED(HttpStatus.BAD_REQUEST, "상품 미디어는 최소 1개 이상이어야 합니다."),
     AUCTION_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 경매입니다."),
     INVALID_BUY_NOW_PRICE(HttpStatus.BAD_REQUEST, "즉시 구매가는 현재 입찰가보다 낮을 수 없습니다."),
-    COMPLETED_ITEM_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "거래가 완료된 상품은 삭제할 수 없습니다."),
+    SOLD_ITEM_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "거래가 완료된 상품은 삭제할 수 없습니다."),
+    ITEM_WITH_BID_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "입찰 이력이 있는 상품은 삭제할 수 없습니다."),
 
     // Bid
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -112,7 +112,7 @@ public class Item extends BaseEntity {
         return this.status != ItemStatus.ACTIVE;
     }
 
-    public boolean isCompleted() {
+    public boolean isSold() {
         return this.status == ItemStatus.BID_CLOSED
                 || this.status == ItemStatus.BUY_NOW_CLOSED;
     }

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/enums/ItemStatus.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/enums/ItemStatus.java
@@ -4,6 +4,5 @@ public enum ItemStatus {
     ACTIVE,
     BID_CLOSED,
     NO_BID_CLOSED,
-    BUY_NOW_CLOSED,
-    CANCELED
+    BUY_NOW_CLOSED
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -115,12 +115,16 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.ITEM_DELETE_FORBIDDEN);
         }
 
-        if (item.isCompleted()) {
-            throw new BusinessException(ErrorCode.COMPLETED_ITEM_CANNOT_BE_DELETED);
+        if (item.isSold()) {
+            throw new BusinessException(ErrorCode.SOLD_ITEM_CANNOT_BE_DELETED);
+        }
+
+        boolean hasBid = bidRepository.existsByItemId(itemId);
+        if (hasBid) {
+            throw new BusinessException(ErrorCode.ITEM_WITH_BID_CANNOT_BE_DELETED);
         }
 
         wishRepository.deleteAllByItemId(itemId);
-        bidRepository.deleteAllByItemId(itemId);
         itemMediaService.deleteAllByItemId(itemId);
         itemRepository.delete(item);
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #52 

<br>

## 📝 작업 내용 (Description)

  - 수동 경매 종료 기능을 제거하고 `ItemStatus.CANCELED` 상태를 삭제했다.

  - 상품 삭제 가능 조건을 아래와 같이 재정의했다.
    - 본인(판매자)일 것
    - 낙찰/즉시구매로 거래 완료되지 않은 상태 (`BID_CLOSED`, `BUY_NOW_CLOSED` 제외)
    - 입찰 이력이 없는 상태

  - 삭제 조건별 에러코드를 분리했다.
    - `SOLD_ITEM_CANNOT_BE_DELETED` : 거래 완료된 상품
    - `ITEM_WITH_BID_CANNOT_BE_DELETED` : 입찰 이력이 있는 상품

<br>

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

<br>

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x]  기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

<br>