### PR TITLE
refactor: 찜 목록 조회 N+1 쿼리 개선

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -63,8 +63,9 @@ public class SecurityConfig {
     public CorsConfigurationSource configurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
-                "http://localhost:5173",
-                "https://ignoa-web.vercel.app"
+                "http://localhost:35173",
+                "https://ignoa-web.vercel.app",
+                "https://ignoa.wisoft.dev"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemMediaRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemMediaRepository.java
@@ -27,4 +27,10 @@ public interface ItemMediaRepository extends JpaRepository<ItemMedia, Long> {
     int countByItemIdAndIdIn(Long itemId, List<Long> ids);
 
     List<ItemMedia> findAllByItemIdAndIdIn(Long itemId, List<Long> mediaIds);
+
+    @Query("SELECT m.item.id, m.mediaUrl " +
+            "FROM ItemMedia m " +
+            "WHERE m.item.id IN :itemIds " +
+            "ORDER BY m.id ASC")
+    List<Object[]> findByItemIdIn(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -113,8 +113,8 @@ public class ItemCommandService {
                 request.endAt());
 
         if (!CollectionUtils.isEmpty(request.deleteMediaIds())) {
-            itemMediaService.validateMinimumMediaCount(itemId, request.deleteMediaIds(), files);
-            itemMediaService.deleteByIds(itemId, request.deleteMediaIds());
+            itemMediaService.validateMediaCount(itemId, request.deleteMediaIds(), files);
+            itemMediaService.deleteMedias(itemId, request.deleteMediaIds());
         }
 
         if (!CollectionUtils.isEmpty(files)) {
@@ -146,7 +146,7 @@ public class ItemCommandService {
         }
 
         wishRepository.deleteAllByItemId(itemId);
-        itemMediaService.deleteAllByItemId(itemId);
+        itemMediaService.deleteAllMedia(itemId);
         itemRepository.delete(item);
 
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,17 +35,29 @@ public class ItemMediaService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_MEDIA_NOT_FOUND));
     }
 
-    public List<ItemMediaResponse> getMediaUrlByItemId(Long itemId) {
-        return itemMediaRepository.findAllByItemIdOrderByIdAsc(itemId).stream()
-                .map(itemMedia ->
-                        new ItemMediaResponse(itemMedia.getId(), itemMedia.getMediaUrl()))
+    public Map<Long, String> getFirstMediaUrlMap(List<Long> itemIds) {
+        return itemMediaRepository
+                .findByItemIdIn(itemIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (String) row[1],
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    public List<ItemMediaResponse> getMediaUrls(Long itemId) {
+        return itemMediaRepository
+                .findAllByItemIdOrderByIdAsc(itemId).stream()
+                .map(itemMedia -> new ItemMediaResponse(itemMedia.getId(), itemMedia.getMediaUrl()))
                 .toList();
     }
 
-    public void validateMinimumMediaCount(Long itemId, List<Long> mediaIds, List<MultipartFile> files) {
+    public void validateMediaCount(
+            Long itemId, List<Long> mediaIds, List<MultipartFile> files
+    ) {
         int currentCount = itemMediaRepository.countByItemId(itemId);
         int toDeleteCount = itemMediaRepository.countByItemIdAndIdIn(itemId, mediaIds);
-        int addCount = files == null ? 0 : (int) files.stream().filter(file -> !file.isEmpty()).count();
+        int addCount = files == null ? 0 : files.size();
 
         if (currentCount - toDeleteCount + addCount < 1) {
             throw new BusinessException(ErrorCode.ITEM_MEDIA_REQUIRED);
@@ -52,21 +66,16 @@ public class ItemMediaService {
 
     @Transactional
     public void save(Item item, List<MultipartFile> files) {
-        List<ItemMedia> itemMediaList = files.stream()
-                .filter(file -> !file.isEmpty())
-                .map(file -> {
+        files.stream().filter(file -> !file.isEmpty())
+                .forEach(file -> {
                     String mediaUrl = storageService.upload(file);
-                    return ItemMedia.from(item, mediaUrl, ItemMediaType.from(file.getOriginalFilename()));
-                })
-                .toList();
-
-        if (!itemMediaList.isEmpty()) {
-            itemMediaRepository.saveAll(itemMediaList);
-        }
+                    ItemMedia itemMedia = ItemMedia.from(item, mediaUrl, ItemMediaType.from(file.getContentType()));
+                    itemMediaRepository.save(itemMedia);
+                });
     }
 
     @Transactional
-    public void deleteByIds(Long itemId, List<Long> mediaIds) {
+    public void deleteMedias(Long itemId, List<Long> mediaIds) {
         itemMediaRepository.findAllByItemIdAndIdIn(itemId, mediaIds)
                 .forEach(itemMedia -> outboxAppender.save(
                         itemId.toString(), "ITEM", itemMedia.getMediaUrl(), OutboxEventType.DELETE_ITEM_IMAGE
@@ -76,7 +85,7 @@ public class ItemMediaService {
     }
 
     @Transactional
-    public void deleteAllByItemId(Long itemId) {
+    public void deleteAllMedia(Long itemId) {
         itemMediaRepository.findAllByItemId(itemId)
                 .forEach(itemMedia -> outboxAppender.save(
                         itemId.toString(), "ITEM", itemMedia.getMediaUrl(), OutboxEventType.DELETE_ITEM_IMAGE

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
@@ -53,7 +53,7 @@ public class ItemQueryService {
         boolean isBidder = topBid.isPresent();
         boolean isTopBidder = topBid.map(bid -> bid.getPrice().equals(item.getCurrentPrice())).orElse(false);
         boolean isSeller = userId != null && item.isSeller(userId);
-        List<ItemMediaResponse> mediaUrls = itemMediaService.getMediaUrlByItemId(itemId);
+        List<ItemMediaResponse> mediaUrls = itemMediaService.getMediaUrls(itemId);
         int wishCount = getWishCount(itemId);
         int bidCount = getBidCount(itemId);
         boolean isWished = userId != null && wishRepository.existsByUserIdAndItemId(userId, itemId);
@@ -90,6 +90,11 @@ public class ItemQueryService {
 
     public Item getItemWithSeller(Long itemId) {
         return itemRepository.findByIdWithSeller(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+
+    public Item findById(Long itemId) {
+        return itemRepository.findById(itemId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/wish/controller/WishController.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/controller/WishController.java
@@ -2,7 +2,7 @@ package io.wisoft.ignoa_api.wish.controller;
 
 import io.wisoft.ignoa_api.global.common.ApiResponse;
 import io.wisoft.ignoa_api.global.common.SliceResponse;
-import io.wisoft.ignoa_api.wish.dto.request.WishListRequest;
+import io.wisoft.ignoa_api.wish.dto.request.WishPreviewRequest;
 import io.wisoft.ignoa_api.wish.dto.response.WishPreview;
 import io.wisoft.ignoa_api.wish.service.WishService;
 import jakarta.validation.Valid;
@@ -41,7 +41,7 @@ public class WishController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<SliceResponse<WishPreview>>> getWishes(
-            @Valid @ModelAttribute WishListRequest request,
+            @Valid @ModelAttribute WishPreviewRequest request,
             @AuthenticationPrincipal Long userId
     ) {
         SliceResponse<WishPreview> data = wishService.getWishes(userId, request);

--- a/src/main/java/io/wisoft/ignoa_api/wish/dto/request/WishPreviewRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/dto/request/WishPreviewRequest.java
@@ -2,14 +2,14 @@ package io.wisoft.ignoa_api.wish.dto.request;
 
 import jakarta.validation.constraints.Min;
 
-public record WishListRequest(
+public record WishPreviewRequest(
         @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
         Integer page,
 
         @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
         Integer size
 ) {
-    public WishListRequest {
+    public WishPreviewRequest {
         page = page == null ? 0 : page;
         size = size == null ? 10 : size;
     }

--- a/src/main/java/io/wisoft/ignoa_api/wish/dto/response/WishPreview.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/dto/response/WishPreview.java
@@ -1,5 +1,6 @@
 package io.wisoft.ignoa_api.wish.dto.response;
 
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.wish.entity.Wish;
 
 import java.time.LocalDateTime;
@@ -11,11 +12,12 @@ public record WishPreview(
         String category,
         Long currentPrice,
         Integer wishCount,
+        ItemStatus itemStatus,
         LocalDateTime endAt,
         String mediaUrl,
         LocalDateTime wishedAt
 ) {
-    public static WishPreview from(Wish wish, String mediaUrl, int wishCount) {
+    public static WishPreview from(Wish wish, String mediaUrl, int wishCount, ItemStatus itemStatus) {
         return new WishPreview(
                 wish.getId(),
                 wish.getItem().getId(),
@@ -23,6 +25,7 @@ public record WishPreview(
                 wish.getItem().getCategory(),
                 wish.getItem().getCurrentPrice(),
                 wishCount,
+                itemStatus,
                 wish.getItem().getEndAt(),
                 mediaUrl,
                 wish.getCreatedAt()

--- a/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
@@ -7,20 +7,30 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
+
+    Optional<Wish> findByUserIdAndItemId(Long userId, Long itemId);
 
     int countByItemId(Long itemId);
 
     boolean existsByUserIdAndItemId(Long userId, Long itemId);
 
-    Optional<Wish> findByUserIdAndItemId(Long userId, Long itemId);
-
-    @Query("SELECT w FROM Wish w JOIN FETCH w.item i JOIN FETCH i.seller WHERE w.user.id = :userId ORDER BY w.createdAt DESC")
-    Slice<Wish> findByUserIdWithItem(@Param("userId") Long userId, Pageable pageable);
-
     void deleteAllByItemId(Long itemId);
 
     void deleteAllByUserId(Long userId);
+
+    @Query("SELECT w " +
+            "FROM Wish w JOIN FETCH w.item i JOIN FETCH i.seller " +
+            "WHERE w.user.id = :userId " +
+            "ORDER BY w.createdAt DESC")
+    Slice<Wish> findByUserIdWithItem(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT w.item.id, COUNT(w) " +
+            "FROM Wish w " +
+            "WHERE w.item.id IN :itemIds " +
+            "GROUP BY w.item.id")
+    List<Object[]> countByItemIds(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
@@ -4,14 +4,14 @@ import io.wisoft.ignoa_api.global.common.SliceResponse;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemMediaService;
-import io.wisoft.ignoa_api.wish.dto.request.WishListRequest;
+import io.wisoft.ignoa_api.item.service.ItemQueryService;
+import io.wisoft.ignoa_api.user.service.UserQueryService;
+import io.wisoft.ignoa_api.wish.dto.request.WishPreviewRequest;
 import io.wisoft.ignoa_api.wish.dto.response.WishPreview;
 import io.wisoft.ignoa_api.wish.entity.Wish;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import io.wisoft.ignoa_api.user.entity.User;
-import io.wisoft.ignoa_api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -19,24 +19,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WishService {
 
-    private final WishRepository wishRepository;
-    private final ItemRepository itemRepository;
-    private final UserRepository userRepository;
+    private final UserQueryService userQueryService;
     private final ItemMediaService itemMediaService;
+    private final ItemQueryService itemQueryService;
+    private final WishRepository wishRepository;
 
     @Transactional
     public void addWish(Long itemId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        User user = userQueryService.findById(userId);
+        Item item = itemQueryService.findById(itemId);
 
         if (wishRepository.existsByUserIdAndItemId(userId, itemId)) {
             throw new BusinessException(ErrorCode.WISH_ALREADY_EXISTS);
@@ -53,16 +52,33 @@ public class WishService {
         wishRepository.delete(wish);
     }
 
-    public SliceResponse<WishPreview> getWishes(Long userId, WishListRequest request) {
-        Slice<Wish> wishSlice = wishRepository.findByUserIdWithItem(userId, PageRequest.of(request.page(), request.size()));
+    public SliceResponse<WishPreview> getWishes(Long userId, WishPreviewRequest request) {
+        Slice<Wish> wishSlice = wishRepository
+                .findByUserIdWithItem(userId, PageRequest.of(request.page(), request.size()));
 
-        List<WishPreview> wishSummaries = wishSlice.getContent().stream()
-                .map(wish -> WishPreview.from(
-                        wish,
-                        itemMediaService.getFirstMediaUrl(wish.getItem().getId()),
-                        wishRepository.countByItemId(wish.getItem().getId())))
+        if (wishSlice.isEmpty()) {
+            return SliceResponse.of(List.of(), wishSlice.hasNext());
+        }
+
+        List<Long> itemIds = wishSlice.getContent().stream()
+                .map(wish -> wish.getItem().getId())
                 .toList();
 
-        return SliceResponse.of(wishSummaries, wishSlice.hasNext());
+        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrlMap(itemIds);
+        Map<Long, Integer> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> ((Long) row[1]).intValue()
+                ));
+
+        List<WishPreview> wishPreview = wishSlice.getContent().stream()
+                .map(wish -> WishPreview.from(
+                        wish,
+                        mediaUrlMap.get(wish.getItem().getId()),
+                        wishCountMap.get(wish.getItem().getId()),
+                        wish.getItem().getStatus()
+                )).toList();
+
+        return SliceResponse.of(wishPreview, wishSlice.hasNext());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #58 

## 📝 작업 내용 (Description)

  **찜 목록 조회 N+1 개선**
  - `WishRepository`에 `itemIds` 배치 조회 쿼리 추가 (IN절 + GROUP BY)
  - `ItemMediaRepository`에 미디어 URL 배치 조회 쿼리 추가
  - `ItemMediaService`에 `getFirstMediaUrlMap()` 배치 조회 메서드 추가
  - `WishService`에서 Map 기반 조회로 N+1 제거

  **의존성 정리**
  - `WishService`에서 `ItemRepository`, `UserRepository` 직접 의존 제거
  - `ItemQueryService`, `UserQueryService`를 통한 조회로 변경
  - `ItemQueryService`에 `findById()` 메서드 추가

**메서드 및 클래스 네이밍 정리**
  - `WishListRequest` → `WishPreviewRequest` 이름 변경
  - `ItemMediaService` 메서드명 정리
    - validateMinimumMediaCount → validateMediaCount,
    -  deleteByIds → deleteMedias
    -  deleteAllByItemId → deleteAllMedia
    -  getMediaUrlByItemId → getMediaUrls

  **CORS 설정**
  - 허용 origin에 https://ignoa.wisoft.dev 추가
  - 로컬 개발 포트 35173으로 변경

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [x] 🔧 기타 (chore)

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

