### PR TITLE
refactor: 상품 목록 조회 성능 개선 (N+1 제거 · 복합 인덱스 · 정렬 안정화)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/seed/LocalDataSeeder.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/seed/LocalDataSeeder.java
@@ -1,0 +1,70 @@
+package io.wisoft.ignoa_api.global.seed;
+
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.ItemMedia;
+import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
+import io.wisoft.ignoa_api.item.entity.enums.ItemMediaType;
+import io.wisoft.ignoa_api.item.repository.ItemMediaRepository;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import io.wisoft.ignoa_api.wish.entity.Wish;
+import io.wisoft.ignoa_api.wish.repository.WishRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Profile("local")
+@Component
+@RequiredArgsConstructor
+public class LocalDataSeeder implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ItemMediaRepository itemMediaRepository;
+    private final WishRepository wishRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+
+        if (itemRepository.count() > 100) return;
+
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            users.add(new User("user" + i + "@test.com", "pw", "nick" + i, "주소" + i));
+        }
+        userRepository.saveAll(users);
+
+        List<Item> items = new ArrayList<>();
+        for (int i = 0; i < 30000; i++) {
+            User seller = users.get(i % users.size());
+            LocalDateTime endAt = LocalDateTime.now().plusDays((i % 30) + 1);
+            items.add(Item.create(seller, "상품" + i, "설명", "카테고리" + (i % 5),
+                    ItemCondition.GOOD, 1000L, 50000L, "브랜드", endAt));
+        }
+        itemRepository.saveAll(items);
+
+        List<ItemMedia> medias = new ArrayList<>();
+        for (Item item : items) {
+            medias.add(ItemMedia.from(item, "https://dummy/img.jpg", ItemMediaType.IMAGE));
+        }
+        itemMediaRepository.saveAll(medias);
+
+        List<Wish> wishes = new ArrayList<>();
+        for (int idx = 0; idx < items.size(); idx++) {
+            int wishCount = (idx < 50) ? 300 : (idx % 5);
+            for (int u = 0; u < wishCount; u++) {
+                wishes.add(Wish.create(users.get(u), items.get(idx)));
+            }
+        }
+        wishRepository.saveAll(wishes);
+    }
+}
+
+

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemPreview.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/response/ItemPreview.java
@@ -13,7 +13,6 @@ public record ItemPreview(
         Long currentPrice,
         Boolean isWished,
         Integer wishCount,
-        Long viewCount,
         ItemStatus status,
         LocalDateTime endAt
 ) {
@@ -27,7 +26,6 @@ public record ItemPreview(
                 item.getCurrentPrice(),
                 isWished,
                 wishCount,
-                item.getViewCount(),
                 item.getStatus(),
                 item.getEndAt()
         );

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -13,7 +13,11 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "items")
+@Table(name = "items",
+        indexes = {
+            @Index(name = "idx_items_status_created", columnList = "status, created_at"),
+            @Index(name = "idx_items_status_end_at", columnList = "status, end_at")
+        })
 public class Item extends BaseEntity {
 
     @Id

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -60,9 +60,6 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime endAt;
 
-    @Column(nullable = false)
-    private Long viewCount = 0L;
-
     public static Item create(User seller, String title, String description, String category,
                               ItemCondition itemCondition, Long startPrice, Long buyNowPrice,
                               String brand, LocalDateTime endAt) {
@@ -79,8 +76,7 @@ public class Item extends BaseEntity {
                 buyNowPrice,
                 brand,
                 ItemStatus.ACTIVE,
-                endAt,
-                0L
+                endAt
         );
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -16,41 +16,50 @@ import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-    @Query("SELECT i FROM Item i " +
-            "WHERE i.status = 'ACTIVE' " +
-            "AND (:category IS NULL OR i.category = :category) " +
-            "ORDER BY (SELECT COUNT(w) " +
-            "          FROM Wish w " +
-            "          WHERE w.item = i) " +
-            "          DESC, i.createdAt DESC")
+    @Query("""
+            SELECT i FROM Item i
+            WHERE i.status = 'ACTIVE'
+            AND (:category IS NULL OR i.category = :category)
+            ORDER BY (SELECT COUNT(w) FROM Wish w WHERE w.item = i) DESC, i.createdAt DESC
+            """)
     Slice<Item> findPopularItems(@Param("category") String category, Pageable pageable);
 
-    @Query("SELECT i FROM Item i " +
-            "WHERE i.status = 'ACTIVE' " +
-            "AND (:category IS NULL OR i.category = :category) " +
-            "ORDER BY i.endAt ASC")
+    @Query("""
+            SELECT i FROM Item i
+            WHERE i.status = 'ACTIVE'
+            AND (:category IS NULL OR i.category = :category)
+            ORDER BY i.endAt ASC
+            """)
     Slice<Item> findEndingSoonItems(@Param("category") String category, Pageable pageable);
 
-    @Query("SELECT i FROM Item i " +
-            "WHERE i.status = 'ACTIVE' " +
-            "AND (:category IS NULL OR i.category = :category) " +
-            "ORDER BY i.createdAt DESC")
+    @Query("""
+            SELECT i FROM Item i
+            WHERE i.status = 'ACTIVE'
+            AND (:category IS NULL OR i.category = :category)
+            ORDER BY i.createdAt DESC
+            """)
     Slice<Item> findLatestItems(@Param("category") String category, Pageable pageable);
 
-    @Query("SELECT i FROM Item i " +
-            "WHERE i.seller.id = :sellerId " +
-            "ORDER BY i.createdAt DESC")
+    @Query("""
+            SELECT i FROM Item i
+            WHERE i.seller.id = :sellerId
+            ORDER BY i.createdAt DESC
+            """)
     List<Item> findItemsBySellerId(@Param("sellerId") Long sellerId);
 
-    @Query("SELECT DISTINCT i FROM Item i " +
-            "JOIN Bid b ON b.item = i " +
-            "WHERE b.bidder.id = :bidderId " +
-            "ORDER BY i.createdAt DESC")
+    @Query("""
+            SELECT DISTINCT i FROM Item i
+            JOIN Bid b ON b.item = i
+            WHERE b.bidder.id = :bidderId
+            ORDER BY i.createdAt DESC
+            """)
     List<Item> findItemsByBidderId(@Param("bidderId") Long bidderId);
 
-    @Query("SELECT i FROM Item i " +
-            "JOIN FETCH i.seller " +
-            "WHERE i.id = :itemId")
+    @Query("""
+            SELECT i FROM Item i
+            JOIN FETCH i.seller
+            WHERE i.id = :itemId
+            """)
     Optional<Item> findByIdWithSeller(@Param("itemId") Long itemId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -18,9 +18,11 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @Query("""
             SELECT i FROM Item i
+            LEFT JOIN Wish w ON w.item = i
             WHERE i.status = 'ACTIVE'
             AND (:category IS NULL OR i.category = :category)
-            ORDER BY (SELECT COUNT(w) FROM Wish w WHERE w.item = i) DESC, i.createdAt DESC
+            GROUP BY i
+            ORDER BY COUNT(w) DESC, i.createdAt DESC, i.id DESC
             """)
     Slice<Item> findPopularItems(@Param("category") String category, Pageable pageable);
 
@@ -28,7 +30,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             SELECT i FROM Item i
             WHERE i.status = 'ACTIVE'
             AND (:category IS NULL OR i.category = :category)
-            ORDER BY i.endAt ASC
+            ORDER BY i.endAt ASC, i.id ASC
             """)
     Slice<Item> findEndingSoonItems(@Param("category") String category, Pageable pageable);
 
@@ -36,7 +38,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             SELECT i FROM Item i
             WHERE i.status = 'ACTIVE'
             AND (:category IS NULL OR i.category = :category)
-            ORDER BY i.createdAt DESC
+            ORDER BY i.createdAt DESC, i.id DESC
             """)
     Slice<Item> findLatestItems(@Param("category") String category, Pageable pageable);
 

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
@@ -17,8 +17,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -55,25 +55,36 @@ public class ItemQueryService {
     }
 
     public SliceResponse<ItemPreview> getItems(ItemPreviewRequest request, Long userId) {
-        Slice<Item> itemSlice = getItemsByView(request, PageRequest.of(request.page(), request.size()));
+        Pageable pageable = PageRequest.of(request.page(), request.size());
+
+        Slice<Item> itemSlice =
+                switch (request.view()) {
+                    case ALL, LATEST -> itemRepository.findLatestItems(request.category(), pageable);
+                    case POPULAR -> itemRepository.findPopularItems(request.category(), pageable);
+                    case ENDING_SOON -> itemRepository.findEndingSoonItems(request.category(), pageable);
+                };
+
+        List<Long> itemIds = itemSlice.getContent().stream()
+                .map(Item::getId).toList();
+
+        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrlMap(itemIds);
+        Map<Long, Integer> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> ((Long) row[1]).intValue()));
+        Set<Long> isWishedSet = (userId == null)
+                ? Set.of()
+                : new HashSet<>(wishRepository.findWishedItemIds(userId, itemIds));
 
         List<ItemPreview> itemPreviewList = itemSlice.getContent().stream()
                 .map(item -> ItemPreview.from(
                         item,
-                        itemMediaService.getFirstMediaUrl(item.getId()),
-                        wishRepository.countByItemId(item.getId()),
-                        userId != null && wishRepository.existsByUserIdAndItemId(userId, item.getId())
+                        mediaUrlMap.get(item.getId()),
+                        wishCountMap.getOrDefault(item.getId(), 0),
+                        isWishedSet.contains(item.getId())
                 )).toList();
 
         return SliceResponse.of(itemPreviewList, itemSlice.hasNext());
-    }
-
-    private Slice<Item> getItemsByView(ItemPreviewRequest request, Pageable pageable) {
-        return switch (request.view()) {
-            case ALL, LATEST -> itemRepository.findLatestItems(request.category(), pageable);
-            case POPULAR -> itemRepository.findPopularItems(request.category(), pageable);
-            case ENDING_SOON -> itemRepository.findEndingSoonItems(request.category(), pageable);
-        };
     }
 
     public List<ItemPreview> getMyItems(Long userId) {

--- a/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/repository/UserRepository.java
@@ -18,8 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    List<User> findAllByDeletedAtBefore(LocalDateTime deletedAtBefore);
-
     Optional<User> findByProviderAndOauthId(String provider, String oauthId);
 
     @Query("""

--- a/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
@@ -33,4 +33,12 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
             "WHERE w.item.id IN :itemIds " +
             "GROUP BY w.item.id")
     List<Object[]> countByItemIds(@Param("itemIds") List<Long> itemIds);
+
+    @Query("""
+            SELECT w.item.id
+            FROM Wish w
+            WHERE w.item.id IN :itemIds
+            AND w.user.id = :userId
+            """)
+    List<Long> findWishedItemIds(@Param("userId") Long userId, @Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
@@ -81,4 +81,5 @@ public class WishService {
 
         return SliceResponse.of(wishPreview, wishSlice.hasNext());
     }
+
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        generate_statistics: true
     open-in-view: false
 
   data:


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #64 
- resolves: #65  
- resolves: #66 

<br>

## 📝 작업 내용 (Description)

> 상품 목록 조회의 성능을 세 단계에 걸쳐 개선했습니다.
> **애플리케이션 레벨(N+1) → 인덱스 레벨 → SQL 레벨** 순으로 진행했습니다.

  ### 1. 목록 조회 N+1 제거 (#64)
  - 로컬 검증용 `LocalDataSeeder` 추가 (local 프로파일 한정)
  - 기존: 조회된 상품마다 대표 미디어 URL / 찜 수 / 찜 여부를 단건으로 반복 조회 → 페이지 크기에 비례해 쿼리 수가 증가
  - 변경: 조회된 상품 ID를 먼저 모은 뒤, 부가 정보를 ID 묶음 단위로 일괄 조회
    - `itemMediaService.getFirstMediaUrlMap(itemIds)` → 대표 미디어 일괄 조회
    - `wishRepository.countByItemIds(itemIds)` → 찜 수 집계 후 Map 변환
    - `wishRepository.findWishedItemIds(userId, itemIds)` → 찜 여부 Set 조회

  ### 2. 정렬/필터용 복합 인덱스 추가 (#65)
  - `items` 테이블에 조회 패턴에 맞춘 복합 인덱스 추가
    - `idx_items_status_created (status, created_at)` → 최신순 피드
    - `idx_items_status_end_at (status, end_at)` → 마감 임박순 피드
  - `status = ACTIVE` 필터와 정렬을 인덱스 단계에서 함께 처리

  ### 3. 인기순 집계 전환 및 정렬 안정화 (#66)
  - 인기순: ORDER BY 절의 상관 서브쿼리(상품 행마다 찜 수 재계산)를 `LEFT JOIN Wish + GROUP BY + COUNT` 집계 방식으로 전환
  - 모든 피드 정렬에 고유 식별자 **tiebreaker** 추가
    - 인기순: `COUNT(w) DESC, created_at DESC, id DESC`
    - 마감 임박순: `end_at ASC, id ASC`
    - 최신순: `created_at DESC, id DESC`
 - 정렬 값이 동일한 항목의 순서를 확정하여 페이지네이션 중복/누락 방지

<br>

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

<br>

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다
