### PR TITLE
refactor: Item 조회 계층 분리 및 목록 조립 중복 제거

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -7,6 +7,7 @@ import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.item.service.ItemReader;
 import io.wisoft.ignoa_api.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,12 +24,12 @@ public class AuctionCloseService {
 
     private final BidService bidService;
     private final BidRepository bidRepository;
+    private final ItemReader itemReader;
     private final ItemRepository itemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void closeAuction(Long itemId) {
-        Item item = itemRepository.findByIdWithLock(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        Item item = itemReader.getByIdWithLock(itemId);
 
         if (item.isClosed()) {
             log.info("[중복 마감 방지] 이미 마감된 경매 itemId={} status={}", itemId, item.getStatus());

--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.bid.repository;
 
 import io.wisoft.ignoa_api.bid.entity.Bid;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,6 +29,14 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
     Optional<Bid> findTopByBidderIdAndItemIdOrderByPriceDesc(Long bidderId, Long itemId);
 
+//    @Query("""
+//          SELECT b FROM Bid b
+//          JOIN FETCH b.bidder
+//          WHERE b.item.id = :itemId
+//          ORDER BY b.price DESC
+//          LIMIT 1
+//          """)
+    @EntityGraph(attributePaths = "bidder")
     Optional<Bid> findTopByItemIdOrderByPriceDesc(Long itemId);
 
     List<Bid> findByItemId(Long itemId);

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -8,6 +8,7 @@ import io.wisoft.ignoa_api.bid.event.BidPlaceEvent;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.item.service.ItemReader;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
@@ -25,6 +26,7 @@ import java.util.List;
 public class BidService {
 
     private final UserQueryService userQueryService;
+    private final ItemReader itemReader;
     private final ApplicationEventPublisher eventPublisher;
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
@@ -33,8 +35,7 @@ public class BidService {
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
         Long bidPrice = request.price();
         User bidder = userQueryService.findById(bidderId);
-        Item item = itemRepository.findByIdWithLock(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        Item item = itemReader.getByIdWithLock(itemId);
 
         if (item.isSeller(bidderId)) {
             throw new BusinessException(ErrorCode.SELF_BID_NOT_ALLOWED);
@@ -62,17 +63,15 @@ public class BidService {
 
     @Transactional
     public void closeBids(Long itemId) {
-        bidRepository.findByItemId(itemId)
-                .forEach(Bid::closeAsLost);
+        bidRepository.findByItemId(itemId).forEach(Bid::closeAsLost);
     }
 
     public List<BidHistory> getBids(Long itemId) {
         if (!itemRepository.existsById(itemId)) {
             throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
         }
-        List<Bid> bidList = bidRepository.findByItemIdWithBidder(itemId);
 
-        return bidList.stream()
+        return bidRepository.findByItemIdWithBidder(itemId).stream()
                 .map(BidHistory::from)
                 .toList();
     }

--- a/src/main/java/io/wisoft/ignoa_api/global/seed/LocalDataSeeder.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/seed/LocalDataSeeder.java
@@ -46,7 +46,7 @@ public class LocalDataSeeder implements CommandLineRunner {
             User seller = users.get(i % users.size());
             LocalDateTime endAt = LocalDateTime.now().plusDays((i % 30) + 1);
             items.add(Item.create(seller, "상품" + i, "설명", "카테고리" + (i % 5),
-                    ItemCondition.GOOD, 1000L, 50000L, "브랜드", endAt));
+                    ItemCondition.GOOD, "브랜드", 1000L, 50000L, endAt));
         }
         itemRepository.saveAll(items);
 

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -65,8 +65,8 @@ public class Item extends BaseEntity {
     private LocalDateTime endAt;
 
     public static Item create(User seller, String title, String description, String category,
-                              ItemCondition itemCondition, Long startPrice, Long buyNowPrice,
-                              String brand, LocalDateTime endAt) {
+                              ItemCondition itemCondition, String brand, Long startPrice, Long buyNowPrice,
+                              LocalDateTime endAt) {
         return new Item(
                 null,
                 seller,

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -38,6 +38,7 @@ public class ItemCommandService {
     private final UserQueryService userQueryService;
     private final BidService bidService;
 
+    private final ItemReader itemReader;
     private final ApplicationEventPublisher eventPublisher;
 
     private final ItemRepository itemRepository;
@@ -65,14 +66,8 @@ public class ItemCommandService {
 
         Item item = Item.create(
                 seller,
-                request.title(),
-                request.description(),
-                request.category(),
-                request.itemCondition(),
-                request.startPrice(),
-                request.buyNowPrice(),
-                request.brand(),
-                request.endAt()
+                request.title(), request.description(), request.category(), request.itemCondition(), request.brand(),
+                request.startPrice(), request.buyNowPrice(), request.endAt()
         );
 
         itemRepository.save(item);
@@ -85,7 +80,7 @@ public class ItemCommandService {
     public ItemDetail updateItem(
             Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files
     ) {
-        Item item = itemQueryService.getItemWithSeller(itemId);
+        Item item = itemReader.getByIdWithSeller(itemId);
 
         if (!item.isSeller(userId)) {
             throw new BusinessException(ErrorCode.ITEM_UPDATE_FORBIDDEN);
@@ -104,13 +99,10 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.END_AT_TOO_LATE);
         }
 
-        item.update(request.title(),
-                request.description(),
-                request.category(),
-                request.brand(),
-                request.itemCondition(),
-                request.buyNowPrice(),
-                request.endAt());
+        item.update(
+                request.title(), request.description(), request.category(), request.brand(), request.itemCondition(),
+                request.buyNowPrice(), request.endAt()
+        );
 
         if (!CollectionUtils.isEmpty(request.deleteMediaIds())) {
             itemMediaService.validateMediaCount(itemId, request.deleteMediaIds(), files);
@@ -129,7 +121,7 @@ public class ItemCommandService {
     }
 
     public ItemIdResponse deleteItem(Long itemId, Long userId) {
-        Item item = itemQueryService.getItemWithSeller(itemId);
+        Item item = itemReader.getByIdWithSeller(itemId);
 
         if (!item.isSeller(userId)) {
             throw new BusinessException(ErrorCode.ITEM_DELETE_FORBIDDEN);
@@ -155,8 +147,7 @@ public class ItemCommandService {
     }
 
     public BuyNowResponse buyNowItem(Long itemId, Long buyerId) {
-        Item item = itemRepository.findByIdWithLock(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+        Item item = itemReader.getByIdWithLock(itemId);
         User user = userQueryService.findById(buyerId);
 
         if (item.isSeller(buyerId)) {

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemMediaService.java
@@ -28,14 +28,7 @@ public class ItemMediaService {
     private final OutboxAppender outboxAppender;
     private final ItemMediaRepository itemMediaRepository;
 
-    public String getFirstMediaUrl(Long itemId) {
-        return itemMediaRepository
-                .findFirstByItemIdOrderByIdAsc(itemId)
-                .map(ItemMedia::getMediaUrl)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_MEDIA_NOT_FOUND));
-    }
-
-    public Map<Long, String> getFirstMediaUrlMap(List<Long> itemIds) {
+    public Map<Long, String> getFirstMediaUrl(List<Long> itemIds) {
         return itemMediaRepository
                 .findByItemIdIn(itemIds).stream()
                 .collect(Collectors.toMap(
@@ -52,9 +45,7 @@ public class ItemMediaService {
                 .toList();
     }
 
-    public void validateMediaCount(
-            Long itemId, List<Long> mediaIds, List<MultipartFile> files
-    ) {
+    public void validateMediaCount(Long itemId, List<Long> mediaIds, List<MultipartFile> files) {
         int currentCount = itemMediaRepository.countByItemId(itemId);
         int toDeleteCount = itemMediaRepository.countByItemIdAndIdIn(itemId, mediaIds);
         int addCount = files == null ? 0 : files.size();

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemQueryService.java
@@ -8,8 +8,7 @@ import io.wisoft.ignoa_api.item.dto.response.*;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
-import io.wisoft.ignoa_api.global.exception.BusinessException;
-import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.wish.repository.dto.WishCount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,13 +25,14 @@ import java.util.stream.Collectors;
 public class ItemQueryService {
 
     private final ItemMediaService itemMediaService;
+    private final ItemReader itemReader;
 
     private final ItemRepository itemRepository;
     private final WishRepository wishRepository;
     private final BidRepository bidRepository;
 
     public ItemDetail getItem(Long itemId, Long userId) {
-        Item item = getItemWithSeller(itemId);
+        Item item = itemReader.getByIdWithSeller(itemId);
 
         Optional<Bid> myTopBid = userId != null
                 ? bidRepository.findTopByBidderIdAndItemIdOrderByPriceDesc(userId, itemId)
@@ -50,70 +50,53 @@ public class ItemQueryService {
         int wishCount = wishRepository.countByItemId(itemId);
         boolean isWished = userId != null && wishRepository.existsByUserIdAndItemId(userId, itemId);
 
-        return ItemDetail.of(
-                item, mediaUrls, sellerProfile, isTopBidder, isBidder, isSeller, isWished, wishCount);
+        return ItemDetail.of(item, mediaUrls, sellerProfile, isTopBidder, isBidder, isSeller, isWished, wishCount);
     }
 
     public SliceResponse<ItemPreview> getItems(ItemPreviewRequest request, Long userId) {
         Pageable pageable = PageRequest.of(request.page(), request.size());
+        Slice<Item> itemSlice = getItemsByView(request, pageable);
+        List<ItemPreview> itemPreviews = buildPreviews(userId, itemSlice.getContent());
 
-        Slice<Item> itemSlice =
-                switch (request.view()) {
-                    case ALL, LATEST -> itemRepository.findLatestItems(request.category(), pageable);
-                    case POPULAR -> itemRepository.findPopularItems(request.category(), pageable);
-                    case ENDING_SOON -> itemRepository.findEndingSoonItems(request.category(), pageable);
-                };
-
-        List<Long> itemIds = itemSlice.getContent().stream()
-                .map(Item::getId).toList();
-
-        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrlMap(itemIds);
-        Map<Long, Integer> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
-                .collect(Collectors.toMap(
-                        row -> (Long) row[0],
-                        row -> ((Long) row[1]).intValue()));
-        Set<Long> isWishedSet = (userId == null)
-                ? Set.of()
-                : new HashSet<>(wishRepository.findWishedItemIds(userId, itemIds));
-
-        List<ItemPreview> itemPreviewList = itemSlice.getContent().stream()
-                .map(item -> ItemPreview.from(
-                        item,
-                        mediaUrlMap.get(item.getId()),
-                        wishCountMap.getOrDefault(item.getId(), 0),
-                        isWishedSet.contains(item.getId())
-                )).toList();
-
-        return SliceResponse.of(itemPreviewList, itemSlice.hasNext());
+        return SliceResponse.of(itemPreviews, itemSlice.hasNext());
     }
 
     public List<ItemPreview> getMyItems(Long userId) {
-        return itemRepository.findItemsBySellerId(userId).stream()
+        List<Item> items = itemRepository.findItemsBySellerId(userId);
+        return buildPreviews(userId, items);
+    }
+
+    public List<ItemPreview> getMyBidItems(Long userId) {
+        List<Item> items = itemRepository.findItemsByBidderId(userId);
+        return buildPreviews(userId, items);
+    }
+
+    private List<ItemPreview> buildPreviews(Long userId, List<Item> items) {
+        List<Long> itemIds = items.stream()
+                .map(Item::getId)
+                .toList();
+
+        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrl(itemIds);
+        Map<Long, Long> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
+                .collect(Collectors.toMap(WishCount::getItemId, WishCount::getCount));
+        Set<Long> wishedItemIdSet = userId == null
+                ? Set.of()
+                : new HashSet<>(wishRepository.findWishedItemIds(userId, itemIds));
+
+        return items.stream()
                 .map(item -> ItemPreview.from(
                         item,
-                        itemMediaService.getFirstMediaUrl(item.getId()),
-                        wishRepository.countByItemId(item.getId()),
-                        userId != null && wishRepository.existsByUserIdAndItemId(userId, item.getId())
+                        mediaUrlMap.get(item.getId()),
+                        wishCountMap.getOrDefault(item.getId(), 0L).intValue(),
+                        wishedItemIdSet.contains(item.getId())
                 )).toList();
     }
 
-    public List<ItemPreview> getMyBids(Long userId) {
-        return itemRepository.findItemsByBidderId(userId).stream()
-                .map(item -> ItemPreview.from(
-                        item,
-                        itemMediaService.getFirstMediaUrl(item.getId()),
-                        wishRepository.countByItemId(item.getId()),
-                        userId != null && wishRepository.existsByUserIdAndItemId(userId, item.getId())
-                )).toList();
-    }
-
-    public Item getItemWithSeller(Long itemId) {
-        return itemRepository.findByIdWithSeller(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
-    }
-
-    public Item findById(Long itemId) {
-        return itemRepository.findById(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    private Slice<Item> getItemsByView(ItemPreviewRequest request, Pageable pageable) {
+        return switch (request.view()) {
+            case ALL, LATEST -> itemRepository.findLatestItems(request.category(), pageable);
+            case POPULAR -> itemRepository.findPopularItems(request.category(), pageable);
+            case ENDING_SOON -> itemRepository.findEndingSoonItems(request.category(), pageable);
+        };
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemReader.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemReader.java
@@ -1,0 +1,30 @@
+package io.wisoft.ignoa_api.item.service;
+
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ItemReader {
+
+    private final ItemRepository itemRepository;
+
+    public Item getById(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+
+    public Item getByIdWithSeller(Long itemId) {
+        return itemRepository.findByIdWithSeller(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+
+    public Item getByIdWithLock(Long itemId) {
+        return itemRepository.findByIdWithLock(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ITEM_NOT_FOUND));
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/controller/UserController.java
@@ -110,7 +110,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<List<ItemPreview>>> getMyBids(
         @AuthenticationPrincipal Long userId
     ) {
-        List<ItemPreview> data = itemQueryService.getMyBids(userId);
+        List<ItemPreview> data = itemQueryService.getMyBidItems(userId);
         ApiResponse<List<ItemPreview>> response = ApiResponse.of(data, "내 입찰 목록을 조회했습니다.");
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeJob.java
@@ -1,6 +1,8 @@
-package io.wisoft.ignoa_api.user.service;
+package io.wisoft.ignoa_api.user.scheduler;
 
 import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.service.UserCommandService;
+import io.wisoft.ignoa_api.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/scheduler/UserPurgeScheduler.java
@@ -1,6 +1,5 @@
 package io.wisoft.ignoa_api.user.scheduler;
 
-import io.wisoft.ignoa_api.user.service.UserPurgeJob;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;

--- a/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/repository/WishRepository.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.wish.repository;
 
 import io.wisoft.ignoa_api.wish.entity.Wish;
+import io.wisoft.ignoa_api.wish.repository.dto.WishCount;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -28,11 +29,13 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
             "ORDER BY w.createdAt DESC")
     Slice<Wish> findByUserIdWithItem(@Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT w.item.id, COUNT(w) " +
-            "FROM Wish w " +
-            "WHERE w.item.id IN :itemIds " +
-            "GROUP BY w.item.id")
-    List<Object[]> countByItemIds(@Param("itemIds") List<Long> itemIds);
+    @Query("""
+            SELECT w.item.id itemId, COUNT(w) count
+            FROM Wish w 
+            WHERE w.item.id IN :itemIds 
+            GROUP BY w.item.id
+            """)
+    List<WishCount> countByItemIds(@Param("itemIds") List<Long> itemIds);
 
     @Query("""
             SELECT w.item.id

--- a/src/main/java/io/wisoft/ignoa_api/wish/repository/dto/WishCount.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/repository/dto/WishCount.java
@@ -1,0 +1,6 @@
+package io.wisoft.ignoa_api.wish.repository.dto;
+
+public interface WishCount {
+    Long getItemId();
+    Long getCount();
+}

--- a/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
+++ b/src/main/java/io/wisoft/ignoa_api/wish/service/WishService.java
@@ -5,13 +5,14 @@ import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.service.ItemMediaService;
-import io.wisoft.ignoa_api.item.service.ItemQueryService;
+import io.wisoft.ignoa_api.item.service.ItemReader;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
 import io.wisoft.ignoa_api.wish.dto.request.WishPreviewRequest;
 import io.wisoft.ignoa_api.wish.dto.response.WishPreview;
 import io.wisoft.ignoa_api.wish.entity.Wish;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
 import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.wish.repository.dto.WishCount;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -29,13 +30,13 @@ public class WishService {
 
     private final UserQueryService userQueryService;
     private final ItemMediaService itemMediaService;
-    private final ItemQueryService itemQueryService;
+    private final ItemReader itemReader;
     private final WishRepository wishRepository;
 
     @Transactional
     public void addWish(Long itemId, Long userId) {
         User user = userQueryService.findById(userId);
-        Item item = itemQueryService.findById(itemId);
+        Item item = itemReader.getById(itemId);
 
         if (wishRepository.existsByUserIdAndItemId(userId, itemId)) {
             throw new BusinessException(ErrorCode.WISH_ALREADY_EXISTS);
@@ -64,22 +65,21 @@ public class WishService {
                 .map(wish -> wish.getItem().getId())
                 .toList();
 
-        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrlMap(itemIds);
-        Map<Long, Integer> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
+        Map<Long, String> mediaUrlMap = itemMediaService.getFirstMediaUrl(itemIds);
+        Map<Long, Long> wishCountMap = wishRepository.countByItemIds(itemIds).stream()
                 .collect(Collectors.toMap(
-                        row -> (Long) row[0],
-                        row -> ((Long) row[1]).intValue()
+                        WishCount::getItemId,
+                        WishCount::getCount
                 ));
 
         List<WishPreview> wishPreview = wishSlice.getContent().stream()
                 .map(wish -> WishPreview.from(
                         wish,
                         mediaUrlMap.get(wish.getItem().getId()),
-                        wishCountMap.get(wish.getItem().getId()),
+                        wishCountMap.get(wish.getItem().getId()).intValue(),
                         wish.getItem().getStatus()
                 )).toList();
 
         return SliceResponse.of(wishPreview, wishSlice.hasNext());
     }
-
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #68 

<br>

## 📝 작업 내용 (Description)

  - 엔티티 lookup을 `ItemReader`로 분리 (`getById` / `getByIdWithSeller` / `getByIdWithLock`)
    - `ItemQueryService`는 DTO 조회 전용으로 정리
    - Command 서비스가 Query 서비스에 의존하던 구조 해소
  - 목록 조회 공통 조립 로직을 `buildPreviews`로 추출
    - `getItems` / `getMyItems` / `getMyBidItems` 중복 제거, 비로그인 null 가드 일원화
  - 네이밍 정리: `getItemByView → getItemsByView`, `getMyBids → getMyBidItems`
  - 호출처(`ItemCommandService` / `WishService` / `BidService`) `ItemReader`로 교체
  
  <br>

## 🔄 변경 유형 (Type of Change)
- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)


<br>

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다
