### PR TITLE
feat: 업로드 후 트랜잭션 실패 시 고아 파일 보상 처리

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/outbox/service/OutboxAppender.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/outbox/service/OutboxAppender.java
@@ -6,6 +6,8 @@ import io.wisoft.ignoa_api.global.outbox.repository.OutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -15,8 +17,18 @@ public class OutboxAppender {
     private final OutboxRepository outboxRepository;
 
     public void save(String aggregateId, String aggregateType, String imageUrl, OutboxEventType eventType) {
-            Outbox outbox = Outbox.create(aggregateId, aggregateType, eventType, imageUrl);
-            outboxRepository.save(outbox);
-            log.info("Outbox 저장 완료 - aggregateId: {}, eventType: {}", aggregateId, eventType);
+        append(aggregateId, aggregateType, imageUrl, eventType);
+        log.info("Outbox 적재 완료 - aggregateId: {}, imageUrl: {}, eventType: {}", aggregateId, imageUrl, eventType);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveForCompensation(String aggregateId, String aggregateType, String imageUrl, OutboxEventType eventType) {
+        append(aggregateId, aggregateType, imageUrl, eventType);
+        log.warn("보상 Outbox 적재 완료 - aggregateId: {}, imageUrl: {}, eventType: {}", aggregateId, imageUrl, eventType);
+    }
+
+    private void append(String aggregateId, String aggregateType, String imageUrl, OutboxEventType eventType) {
+        Outbox outbox = Outbox.create(aggregateId, aggregateType, eventType, imageUrl);
+        outboxRepository.save(outbox);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -1,6 +1,8 @@
 package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
+import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
+import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
 import io.wisoft.ignoa_api.item.dto.response.ItemDetail;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -20,29 +23,45 @@ public class ItemFacade {
 
     private final StorageService storageService;
     private final ItemCommandService itemCommandService;
+    private final OutboxAppender outboxAppender;
 
-    public ItemIdResponse createItem(
-            Long sellerId, ItemCreateRequest request, List<MultipartFile> files
-    ) {
-        List<UploadedMedia> uploadedMedias = uploadFiles(files);
-        return itemCommandService.createItem(sellerId, request, uploadedMedias);
+    public ItemIdResponse createItem(Long sellerId, ItemCreateRequest request, List<MultipartFile> files) {
+        List<UploadedMedia> uploadedMedias = new ArrayList<>();
+
+        try {
+            uploadFiles(files, uploadedMedias);
+            return itemCommandService.createItem(sellerId, request, uploadedMedias);
+        } catch (RuntimeException e) {
+            compensate(sellerId.toString(), uploadedMedias);
+            throw e;
+        }
     }
 
-    public ItemDetail updateItem(
-            Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files
-    ) {
-        List<UploadedMedia> uploadedMedias = CollectionUtils.isEmpty(files)
-                ? List.of()
-                : uploadFiles(files);
+    public ItemDetail updateItem(Long itemId, Long userId, ItemUpdateRequest request, List<MultipartFile> files) {
+        List<UploadedMedia> uploadedMedias = new ArrayList<>();
 
-        return itemCommandService.updateItem(itemId, userId, request, uploadedMedias);
+        try {
+            uploadFiles(files, uploadedMedias);
+            return itemCommandService.updateItem(itemId, userId, request, uploadedMedias);
+        } catch (RuntimeException e) {
+            compensate(itemId.toString(), uploadedMedias);
+            throw e;
+        }
     }
 
-    private List<UploadedMedia> uploadFiles(List<MultipartFile> files) {
-        return files.stream()
-                .map(file -> new UploadedMedia(
-                        storageService.upload(file),
-                        ItemMediaType.from(file.getContentType())
-                )).toList();
+    private void uploadFiles(List<MultipartFile> files, List<UploadedMedia> uploadedMedias) {
+        if (CollectionUtils.isEmpty(files)) {
+            return;
+        }
+
+        for (MultipartFile file : files) {
+            String mediaUrl = storageService.upload(file);
+            uploadedMedias.add(new UploadedMedia(mediaUrl, ItemMediaType.from(file.getContentType())));
+        }
+    }
+
+    private void compensate(String aggregateId, List<UploadedMedia> uploadedMedias) {
+        uploadedMedias.forEach(uploadedMedia -> outboxAppender.saveForCompensation(
+                aggregateId, "ITEM", uploadedMedia.mediaUrl(), OutboxEventType.DELETE_ITEM_IMAGE));
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -10,6 +10,7 @@ import io.wisoft.ignoa_api.item.dto.response.ItemIdResponse;
 import io.wisoft.ignoa_api.item.entity.enums.ItemMediaType;
 import io.wisoft.ignoa_api.item.service.dto.UploadedMedia;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ItemFacade {
@@ -61,7 +63,17 @@ public class ItemFacade {
     }
 
     private void compensate(String aggregateId, List<UploadedMedia> uploadedMedias) {
-        uploadedMedias.forEach(uploadedMedia -> outboxAppender.saveForCompensation(
-                aggregateId, "ITEM", uploadedMedia.mediaUrl(), OutboxEventType.DELETE_ITEM_IMAGE));
+        try {
+            uploadedMedias.forEach(uploadedMedia -> outboxAppender.saveForCompensation(
+                    aggregateId,
+                    "ITEM",
+                    uploadedMedia.mediaUrl(),
+                    OutboxEventType.DELETE_ITEM_IMAGE));
+        } catch (RuntimeException compensationError) {
+            log.error("보상 Outbox 적재 실패 - 고아 파일 수동 정리 필요 - aggregateId={}, mediaUrls={}",
+                    aggregateId,
+                    uploadedMedias.stream().map(UploadedMedia::mediaUrl).toList(),
+                    compensationError);
+        }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
@@ -3,6 +3,8 @@ package io.wisoft.ignoa_api.user.service;
 import io.wisoft.ignoa_api.auth.service.RefreshTokenService;
 import io.wisoft.ignoa_api.auth.service.TokenBlacklistService;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
+import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
+import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
 import io.wisoft.ignoa_api.user.dto.response.MyProfile;
 import io.wisoft.ignoa_api.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -15,19 +17,29 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class UserFacade {
 
-    private final StorageService storageService;
-    private final RefreshTokenService refreshTokenService;
-    private final TokenBlacklistService tokenBlacklistService;
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+
+    private final StorageService storageService;
+    private final OutboxAppender outboxAppender;
+
+    private final RefreshTokenService refreshTokenService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public MyProfile updateProfileImage(Long userId, MultipartFile image) {
         User user = userQueryService.findById(userId);
 
         String oldImageUrl = user.getProfileImageUrl();
         String newImageUrl = storageService.upload(image);
+
         user.updateProfileImage(newImageUrl);
-        userCommandService.saveProfileImage(user, oldImageUrl);
+
+        try {
+            userCommandService.saveProfileImage(user, oldImageUrl);
+        } catch (RuntimeException e) {
+            outboxAppender.saveForCompensation(userId.toString(), "USER", newImageUrl, OutboxEventType.DELETE_PROFILE_IMAGE);
+            throw e;
+        }
 
         return MyProfile.from(user);
     }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
@@ -48,8 +48,8 @@ public class UserFacade {
     private void compensate(String userId, String mediaUrl) {
         try {
             outboxAppender.saveForCompensation(userId, "USER", mediaUrl, OutboxEventType.DELETE_PROFILE_IMAGE);
-        } catch (RuntimeException compensateError) {
-            log.error("보상 Outbox 적재 실패 - 고아 파일 수동 정리 필요 - userId={}, mediaUrl={}", userId, mediaUrl, compensateError);
+        } catch (RuntimeException compensationError) {
+            log.error("보상 Outbox 적재 실패 - 고아 파일 수동 정리 필요 - userId={}, mediaUrl={}", userId, mediaUrl, compensationError);
         }
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -37,11 +38,19 @@ public class UserFacade {
         try {
             userCommandService.saveProfileImage(user, oldImageUrl);
         } catch (RuntimeException e) {
-            outboxAppender.saveForCompensation(userId.toString(), "USER", newImageUrl, OutboxEventType.DELETE_PROFILE_IMAGE);
+            compensate(userId.toString(), newImageUrl);
             throw e;
         }
 
         return MyProfile.from(user);
+    }
+
+    private void compensate(String userId, String mediaUrl) {
+        try {
+            outboxAppender.saveForCompensation(userId, "USER", mediaUrl, OutboxEventType.DELETE_PROFILE_IMAGE);
+        } catch (RuntimeException compensateError) {
+            log.error("보상 Outbox 적재 실패 - 고아 파일 수동 정리 필요 - userId={}, mediaUrl={}", userId, mediaUrl, compensateError);
+        }
     }
 
     public void deleteMe(Long userId, String accessToken, String refreshToken) {


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #74 

<br>

## 📝 작업 내용 (Description)

트랜잭션 밖(Facade)에서 수행하는 S3 업로드가 **업로드 성공 후 DB 트랜잭션 롤백 시 고아 파일을 남기는 문제**를 해결했습니다.

업로드 이후 트랜잭션이 실패하면, 업로드된 파일을 기존 Outbox 삭제 경로로 위임하여 정리하는 **Compensation(보상) 메커니즘**을 추가.

### 변경 사항

- `OutboxAppender`
  - 롤백된 트랜잭션과 분리하여 커밋될 수 있도록 `REQUIRES_NEW` 기반의 `saveForCompensation()` 추가
  - 보상 적재 실패 시 WARN 로그 기록

- `ItemFacade`
  - 업로드 루프를 `try` 내부로 이동
  - 부분 업로드 실패 및 DB 트랜잭션 실패 모두 보상 처리

- `UserFacade`
  - 프로필 이미지 변경 실패 시 업로드 파일 보상 처리 (단일 파일)

- **예외 처리**
  - 보상은 Best-Effort 방식으로 수행
  - 보상 실패가 원래 예외를 가리지 않도록(masking 방지) ERROR 로그만 기록

<br>

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

<br>

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [ ] 필요한 경우 새로운 테스트를 추가했습니다

<br>

## 💬 추가 코멘트 (Additional Comments)

`ItemFacade.createItem`**의 aggregateId = sellerId**
- 생성 실패 시 `itemId` 역시 롤백되어 존재하지 않으므로, 추적 목적의 `aggregateId`로 `sellerId`를 사용했습니다.
- 실제 삭제는 Worker가 payload(URL)를 기준으로 수행하므로 기능상 영향은 없습니다.

**RustFS 멱등성 확인**
- 존재하지 않는 Key에 대한 DELETE 요청이 `204 No Content`를 반환하는 것을 확인했습니다.
- 따라서 다음 상황에서도 안전하게 동작합니다.
  - Outbox Worker 재처리
  - 중복 보상 이벤트 처리

**이번 PR 범위 제외**
- Presigned URL 기반 업로드
- 스토리지 GC(Garbage Collection)

위 항목들은 업로드 병목이 실측될 경우 별도 이슈로 검토할 예정입니다.