### PR TITLE
refactor(bid): 입찰가 갱신을 조건부 UPDATE로 전환 및 통합 테스트 Testcontainers 격리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 테스트 인프라
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -53,7 +53,12 @@ public class BidService {
             throw new BusinessException(ErrorCode.BID_PRICE_EXCEEDS_BUY_NOW);
         }
 
-        item.raiseBidPrice(bidPrice);
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice);
+
+        if (updatedRows == 0) {
+            throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
+        }
+
         Bid bid = Bid.place(item, bidder, bidPrice);
         bidRepository.save(bid);
         eventPublisher.publishEvent(BidPlaceEvent.of(bid, item, bidder));

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -99,10 +99,6 @@ public class Item extends BaseEntity {
         if (endAt != null) this.endAt = endAt;
     }
 
-    public void raiseBidPrice(Long newPrice) {
-        this.currentPrice = newPrice;
-    }
-
     public boolean isSeller(Long userId) {
         return this.seller.getId().equals(userId);
     }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -5,6 +5,7 @@ import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -65,4 +66,12 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findAllByStatusAndEndAtBefore(ItemStatus status, LocalDateTime endAtBefore);
 
     boolean existsBySellerIdAndStatus(Long userId, ItemStatus status);
+
+    @Modifying
+    @Query("""
+            UPDATE Item i
+            SET i.currentPrice = :price
+            WHERE i.id = :id AND i.currentPrice < :price
+            """)
+    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price);
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,6 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: false
+    open-in-view: false

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -8,12 +8,12 @@ import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.support.IntegrationTestSupport;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.*;
 
-@SpringBootTest
-class BidServiceConcurrencyTest {
+class BidServiceConcurrencyTest extends IntegrationTestSupport {
 
     @Autowired
     BidService bidService;

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -1,7 +1,10 @@
 package io.wisoft.ignoa_api.bid.service;
 
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
+import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
@@ -80,6 +83,69 @@ class BidServiceConcurrencyTest {
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(failCount.get()).isEqualTo(threadCount - 1);
         assertThat(bidRepository.findByItemId(item.getId())).hasSize(1);
+    }
+
+    @Test
+    void 서로_다른_가격으로_동시_입찰해도_최고가만_반영되고_LostUpdate가_없다() throws InterruptedException {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User bidder = userRepository.save(newUser("bidder@test.com", "입찰자"));
+        Item item = itemRepository.save(newItem(seller));
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        // When
+        for (int i = 0; i < threadCount; i++) {
+            long bidPrice = 1_100L + i * 100L;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(bidPrice));
+                } catch (Exception e) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+        startLatch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Then
+        Item finalItem = itemRepository.findById(item.getId()).orElseThrow();
+        long maxSavedBid = bidRepository.findByItemId(item.getId()).stream()
+                .mapToLong(Bid::getPrice)
+                .max()
+                .orElse(0L);
+
+        assertThat(finalItem.getCurrentPrice()).isEqualTo(2_000L);
+        assertThat(finalItem.getCurrentPrice()).isEqualTo(maxSavedBid);
+    }
+
+    @Test
+    void 동일가나_낮은가로_입찰하면_INVALID_BID_PRICE_예외가_발생한다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User bidder = userRepository.save(newUser("bidder@test.com", "입찰자"));
+        Item item = itemRepository.save(newItem(seller));
+        long bidPrice = 1_500L;
+        bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(bidPrice));
+
+        // When
+        BusinessException samePriceException = catchThrowableOfType(
+                BusinessException.class,
+                () -> bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(1_500L)));
+
+        BusinessException lowerPriceException = catchThrowableOfType(
+                BusinessException.class,
+                () -> bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(1_400L)));
+
+        // Then
+        assertThat(samePriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
+        assertThat(lowerPriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
     }
 
     private static User newUser(String email, String nickname) {

--- a/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
+++ b/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
@@ -1,0 +1,33 @@
+package io.wisoft.ignoa_api.support;
+
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+public abstract class IntegrationTestSupport {
+
+    @Container
+    @ServiceConnection
+    static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0");
+
+    @Container
+    static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(
+            "redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port",
+                () -> REDIS_CONTAINER.getMappedPort(6379));
+    }
+}

--- a/src/test/resources/docker-java.properties
+++ b/src/test/resources/docker-java.properties
@@ -1,0 +1,5 @@
+# Docker Engine 29+ 는 최소 API 버전이 1.44 (하드 플로어).
+# Testcontainers 1.21.x가 번들한 docker-java는 기본 1.32로 요청해 400이 발생하므로,
+# 요청 API 버전을 1.44로 고정한다.
+# 장기적으로 Testcontainers 2.0.5+ 로 올라가면 docker-java가 자동 협상하므로 이 파일은 제거 가능.
+api.version=1.44


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #83, #85 

---

## 📝 작업 내용 (Description)

> 입찰 동시성 제어의 정합성 방어선을 Redis 락/@Version에서 **DB 조건부 UPDATE**로 옮기고, 통합 테스트 환경을 **Testcontainers**로 격리했습니다.

### **조건부 UPDATE (#83)**
- 입찰가 갱신을 더티체킹(@Version) → `UPDATE ... WHERE current_price < :price`로 전환
- 영향 0행이면 `INVALID_BID_PRICE`, 1행일 때만 Bid 저장·이벤트 발행
- @Version은 buyNow/경매마감 등 다른 경로 방어용으로 유지
- 미사용이 된 `Item.raiseBidPrice()` 제거

### **Testcontainers 격리 (#85)**
- 통합 테스트가 일회용 MySQL/Redis 컨테이너에서 실행되도록 IntegrationTestSupport 도입
  (MySQL `@ServiceConnection`, Redis `@DynamicPropertySource`)
- `application-test.yaml`(테스트 프로파일), `docker-java.properties`(Docker 29 대응) 추가
- 동시성/가격검증 테스트 추가 (최고가만 반영·Lost Update 없음, 동일가/낮은가 거절)

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [x] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 테스트가 통과합니다
- [x] 필요한 경우 새로운 테스트를 추가했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- **정합성 방어선 이동**: 이번 PR로 정합성이 DB(조건부 UPDATE)에서 보장됩니다.
  - 이는 후속 **Redis fail-open** 작업의 전제이며, fail-open은 별도 PR로 진행합니다.
 
- **Docker Engine 29+ 주의**: 최소 API 버전이 1.44라, `docker-java.properties`에 `api.version=1.44`를 고정.
  - (없으면 Testcontainers가 400)