### PR TITLE
feat: Redis 장애 시 입찰 Fail-Open 및 Phantom Bid 방어

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidFacade.java
@@ -2,11 +2,14 @@ package io.wisoft.ignoa_api.bid.service;
 
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
 import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
+import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BidFacade {
@@ -17,11 +20,16 @@ public class BidFacade {
     private final BidService bidService;
 
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
-        return distributedLock.executeWithLock(
-                ItemLockKey.of(itemId),
-                WAIT_TIME_MILLIS,
-                () -> bidService.placeBid(itemId, bidderId, request)
-        );
+        try {
+            return distributedLock.executeWithLock(
+                    ItemLockKey.of(itemId),
+                    WAIT_TIME_MILLIS,
+                    () -> bidService.placeBid(itemId, bidderId, request)
+            );
+        } catch (LockInfrastructureException e) {
+            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 입찰을 진행 itemId={}, bidderId={}", itemId, bidderId, e);
+            return bidService.placeBid(itemId, bidderId, request);
+        }
     }
 }
 

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -7,6 +7,7 @@ import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.event.BidPlaceEvent;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemReader;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -53,7 +54,7 @@ public class BidService {
             throw new BusinessException(ErrorCode.BID_PRICE_EXCEEDS_BUY_NOW);
         }
 
-        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice);
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, ItemStatus.ACTIVE);
 
         if (updatedRows == 0) {
             throw new BusinessException(ErrorCode.INVALID_BID_PRICE);

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -14,6 +14,9 @@ import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -28,9 +31,10 @@ public class BidService {
 
     private final UserQueryService userQueryService;
     private final ItemReader itemReader;
-    private final ApplicationEventPublisher eventPublisher;
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final EntityManager entityManager;
 
     @Transactional
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
@@ -57,7 +61,7 @@ public class BidService {
         int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, ItemStatus.ACTIVE);
 
         if (updatedRows == 0) {
-            throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
+            resolveBidFailure(item);
         }
 
         Bid bid = Bid.place(item, bidder, bidPrice);
@@ -80,5 +84,19 @@ public class BidService {
         return bidRepository.findByItemIdWithBidder(itemId).stream()
                 .map(BidHistory::from)
                 .toList();
+    }
+
+    private void resolveBidFailure(Item item) {
+        try {
+            entityManager.refresh(item, LockModeType.PESSIMISTIC_READ);
+        } catch (EntityNotFoundException e) {
+            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
+        }
+
+        if (item.isClosed()) {
+            throw new BusinessException(ErrorCode.AUCTION_CLOSED);
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockInfrastructureException.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockInfrastructureException.java
@@ -1,0 +1,7 @@
+package io.wisoft.ignoa_api.global.infra.lock;
+
+public class LockInfrastructureException extends RuntimeException {
+  public LockInfrastructureException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
@@ -7,6 +7,7 @@ import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.RedisException;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
@@ -31,26 +32,30 @@ public class RedissonDistributedLock {
 
     private <T> T execute(String key, long waitMillis, Supplier<T> task) {
         RLock lock = redissonClient.getLock(key);
-        boolean acquired = false;
+        boolean acquired;
 
         try {
             acquired = lock.tryLock(waitMillis, LEASE_TIME_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
+        } catch (RedisException e) {
+            throw new LockInfrastructureException("Redis 인프라 장애 - 분산 락 획득 실패. key = " + key, e);
+        }
 
-            if (!acquired) {
-                throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
-            }
+        if (!acquired) {
+            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
+        }
 
+        try {
             Timer holdTimer = Timer.builder("lock.hold.time")
                     .tag("key", keyPrefix(key))
                     .publishPercentiles(0.5, 0.95, 0.99)
                     .register(meterRegistry);
 
             return holdTimer.record(task);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
         } finally {
-            if (acquired && lock.isHeldByCurrentThread()) {
+            if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
         }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -71,7 +71,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("""
             UPDATE Item i
             SET i.currentPrice = :price
-            WHERE i.id = :id AND i.currentPrice < :price
+            WHERE i.id = :id AND i.currentPrice < :price AND i.status = :status
             """)
-    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price);
+    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price, @Param("status") ItemStatus status);
 }

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidFacadeTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidFacadeTest.java
@@ -1,0 +1,75 @@
+package io.wisoft.ignoa_api.bid.service;
+
+import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
+import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
+import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
+import io.wisoft.ignoa_api.item.support.ItemLockKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BidFacadeTest {
+
+    @Mock
+    RedissonDistributedLock distributedLock;
+
+    @Mock
+    BidService bidService;
+
+    @InjectMocks
+    BidFacade bidFacade;
+
+    @Test
+    void Redis_인프라_장애가_발생하면_락_없이_입찰을_진행한다() {
+        // Given
+        Long itemId = 1L;
+        Long bidderId = 2L;
+        BidCreateRequest request = new BidCreateRequest(1_000L);
+        BidResponse expected = mock(BidResponse.class);
+
+        given(distributedLock.executeWithLock(eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class))).willThrow(
+                new LockInfrastructureException("Redis 장애", new RuntimeException()));
+        given(bidService.placeBid(itemId, bidderId, request)).willReturn(expected);
+
+        // When
+        BidResponse result = bidFacade.placeBid(itemId, bidderId, request);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(bidService).placeBid(itemId, bidderId, request);
+    }
+
+    @Test
+    void Redis_락_획득이_타임아웃되면_입찰에_실패한다() {
+        // Given
+        Long itemId = 1L;
+        Long bidderId = 2L;
+        BidCreateRequest request = new BidCreateRequest(1_000L);
+
+        given(distributedLock.executeWithLock(eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
+                .willThrow(new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED));
+
+        // When
+        BusinessException exception = catchThrowableOfType(
+                BusinessException.class,
+                () -> bidFacade.placeBid(itemId, bidderId, request)
+        );
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.LOCK_ACQUISITION_FAILED);
+        verify(bidService, never()).placeBid(itemId, bidderId, request);
+    }
+}

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -7,6 +7,7 @@ import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.support.IntegrationTestSupport;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -14,6 +15,7 @@ import io.wisoft.ignoa_api.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
@@ -145,6 +147,29 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
         // Then
         assertThat(samePriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
         assertThat(lowerPriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
+    }
+
+    @Test
+    @Transactional
+    void 마감된_상품은_가격_조건을_만족해도_status_가드로_갱신되지_않는다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        Item item = itemRepository.save(newItem(seller));
+
+        long before = item.getCurrentPrice();
+        long bidPrice = item.getCurrentPrice() + 1_000L;
+
+        item.closeWithoutBid();
+        itemRepository.saveAndFlush(item);
+
+        // When
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(
+                item.getId(), bidPrice, ItemStatus.ACTIVE);
+
+        // Then
+        assertThat(updatedRows).isZero();
+        Item reloaded = itemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getCurrentPrice()).isEqualTo(before);
     }
 
     private static User newUser(String email, String nickname) {

--- a/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
@@ -1,0 +1,101 @@
+package io.wisoft.ignoa_api.global.infra.lock;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.RedisException;
+
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RedissonDistributedLockTest {
+
+    @Mock
+    RedissonClient redissonClient;
+
+    @Mock
+    RLock lock;
+
+    RedissonDistributedLock distributedLock;
+
+    @BeforeEach
+    void setUp() {
+        distributedLock = new RedissonDistributedLock(redissonClient, new SimpleMeterRegistry());
+        given(redissonClient.getLock(anyString())).willReturn(lock);
+    }
+
+    @Test
+    void 락_획득이_타임아웃되면_LOCK_ACQUISITION_FAILED를_던진다() throws InterruptedException {
+        // Given
+        String key = "item:lock:1";
+        long waitTime = 250L;
+
+        given(lock.tryLock(anyLong(), anyLong(), any(TimeUnit.class)))
+                .willReturn(false);
+
+        // When
+        BusinessException exception = catchThrowableOfType(
+                BusinessException.class,
+                () -> distributedLock.executeWithLock(key, waitTime, () -> "결과")
+        );
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.LOCK_ACQUISITION_FAILED);
+        verify(lock, never()).unlock();
+    }
+
+    @Test
+    void 락_획득_중_인프라_장애가_발생하면_LockInfrastructureException을_던진다() throws InterruptedException {
+        // Given
+        String key = "item:lock:1";
+        long waitTime = 250L;
+
+        given(lock.tryLock(anyLong(), anyLong(), any(TimeUnit.class)))
+                .willThrow(new RedisException("Redis 장애"));
+
+        // When
+        LockInfrastructureException exception = catchThrowableOfType(
+                LockInfrastructureException.class,
+                () -> distributedLock.executeWithLock(key, waitTime, () -> "결과")
+        );
+
+        // Then
+        assertThat(exception)
+                .isNotNull()
+                .hasCauseInstanceOf(RedisException.class);
+        verify(lock, never()).unlock();
+    }
+
+    @Test
+    void 락을_정상적으로_획득하면_task를_실행하고_결과를_반환한_후_락을_해제한다() throws InterruptedException {
+        // Given
+        String key = "item:lock:1";
+        long waitTime = 250L;
+
+        given(lock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).willReturn(true);
+        given(lock.isHeldByCurrentThread()).willReturn(true);
+
+        // When
+        String result = distributedLock.executeWithLock(key, waitTime, () -> "입찰 완료");
+
+        // Then
+        assertThat(result).isEqualTo("입찰 완료");
+        verify(lock).unlock();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #84 
- related: #83 

---

## 📝 작업 내용 (Description)

  - Redis 분산 락이 입찰의 SPOF가 되는 문제를 해결한다.
  - 락 실패를 인프라 장애와 정상 경합으로 구분해, 인프라 장애일 때만 락을 우회(Fail-Open)한다.
  - 락 없이 진행해도 조건부 UPDATE의 원자성으로 Lost Update가 없으므로 안전하다.

  ### 1. 락 실패 구분 (RedissonDistributedLock)
  - `RedisException`(인프라 장애) → `LockInfrastructureException`으로 분리
  - 락 획득 실패·`InterruptedException` → `LOCK_ACQUISITION_FAILED` 유지

  ### 2. Fail-Open 적용 (BidFacade)
  - 인프라 장애만 catch → WARN 로그 + 락 없이 `bidService.placeBid()` 재실행
  - `LOCK_ACQUISITION_FAILED`는 그대로 전파(Fast-Fail)

  ### 3. Phantom Bid 방어
  - 조건부 UPDATE에 `status='ACTIVE'` 가드 추가
  - UPDATE 0행 시 가격 부족 / 경매 종료 원인 구분

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---