### PR TITLE
fix: buyNow의 currentPrice 되쓰기 방어 (@DynamicUpdate 적용)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -6,11 +6,13 @@ import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "items",

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
@@ -1,0 +1,84 @@
+package io.wisoft.ignoa_api.item.service;
+
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.support.IntegrationTestSupport;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ItemDynamicUpdateTest extends IntegrationTestSupport {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        itemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    void buyNow_flush는_입찰이_갱신한_currentPrice를_덮어쓰지_않는다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "seller"));
+        User buyer = userRepository.save(newUser("buyer@test.com", "buyer"));
+        Item saved = itemRepository.save(newItem(seller));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        long itemId = saved.getId();
+        long before = saved.getCurrentPrice();
+        long raised = before + 1_000L;
+        
+        // When
+        Item item = entityManager.find(Item.class, itemId);
+
+        itemRepository.raiseCurrentPriceIfHigher(itemId, raised, ItemStatus.ACTIVE);
+
+        item.buyNow(buyer);
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then
+        Item reloaded = itemRepository.findById(itemId).orElseThrow();
+        assertThat(reloaded.getCurrentPrice()).isEqualTo(raised);
+    }
+
+    private static User newUser(String email, String nickname) {
+        return new User(email, "password", nickname, "address");
+    }
+
+    private static Item newItem(User seller) {
+        return Item.create(
+                seller,
+                "테스트 상품",
+                "설명",
+                "카테고리",
+                ItemCondition.GOOD,
+                "브랜드",
+                1_000L,
+                1_000_000L,
+                LocalDateTime.now().plusDays(1)
+        );
+    }
+}

--- a/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
+++ b/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
@@ -26,7 +26,7 @@ public abstract class IntegrationTestSupport {
         MYSQL_CONTAINER.start();
         REDIS_CONTAINER.start();
     }
-e
+
     @DynamicPropertySource
     static void redisProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);

--- a/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
+++ b/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
@@ -16,14 +16,17 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public abstract class IntegrationTestSupport {
 
-    @Container
     @ServiceConnection
     static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0");
 
-    @Container
     static final GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(
             "redis:7-alpine").withExposedPorts(6379);
 
+    static {
+        MYSQL_CONTAINER.start();
+        REDIS_CONTAINER.start();
+    }
+e
     @DynamicPropertySource
     static void redisProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #87 
- related: #84 

---

## 📝 작업 내용 (Description)

> 이번 작업의 배경은 다음 이슈를 참고. (#87)

### 1. Item에 @DynamicUpdate 적용
- 변경된 컬럼만 UPDATE하도록 변경
- buyNow UPDATE에서 `currentPrice`를 제외하여 blind write 제거

### 2. Lost Update 방지 테스트 추가 
- EntityManager로 조회→벌크 UPDATE→flush 순서를 제어해 단일 스레드로 재현
- `currentPrice`가 덮어써지지 않음을 검증

### 3. 통합 테스트 컨테이너 싱글톤 전환
- `Testcontainers`, `@Container`의 클래스 단위 생명주기가 Spring 컨텍스트 캐싱과 충돌
- 컨테이너를 **static 블록**에서 JVM당 1회만 시작하도록 변경하여 Connection refused 문제 해결

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [x] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- `show-sql`을 통해 `current_price`가 UPDATE 대상에서 제외되고, `status`, `winner_id` 등 변경된 컬럼만 UPDATE되는 것을 확인.
- 후속 작업(별도 이슈): buyNow 및 수정·삭제 경로를 fail-open으로 전환합니다. (본 변경이 선행 조건)