### PR TITLE
refactor: 즉시구매 정합성을 DB 차원에서 보장 (fail-open 선행 작업)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -73,7 +73,10 @@ public class BidService {
 
     @Transactional
     public void closeBids(Long itemId) {
-        bidRepository.findByItemId(itemId).forEach(Bid::closeAsLost);
+        // TODO
+        // 입찰 N개 SELECT, 각각 Dirty → flush 시 UPDATE N번
+        bidRepository.findByItemId(itemId)
+                .forEach(Bid::closeAsLost);
     }
 
     public List<BidHistory> getBids(Long itemId) {

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.item.repository;
 
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+import io.wisoft.ignoa_api.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -71,7 +72,22 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("""
             UPDATE Item i
             SET i.currentPrice = :price
-            WHERE i.id = :id AND i.currentPrice < :price AND i.status = :status
+            WHERE i.id = :id 
+                AND i.currentPrice < :price
+                AND i.status = :status
             """)
     int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price, @Param("status") ItemStatus status);
+
+    @Modifying
+    @Query("""
+            UPDATE Item i
+            SET i.status = :closedStatus,
+                i.winner = :winner
+            WHERE i.id = :id 
+                AND i.status = :activeStatus 
+            """)
+    int buyNowIfActive(@Param("id") Long id,
+                       @Param("winner") User winner,
+                       @Param("closedStatus") ItemStatus closedStatus,
+                       @Param("activeStatus") ItemStatus activeStatus);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -13,6 +13,7 @@ import io.wisoft.ignoa_api.item.dto.response.ItemDetail;
 import io.wisoft.ignoa_api.item.dto.response.ItemIdResponse;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.ItemMedia;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.dto.UploadedMedia;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -143,11 +144,17 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        item.buyNow(user);
+        int updatedRows = itemRepository.buyNowIfActive(
+                itemId, user, ItemStatus.BUY_NOW_CLOSED, ItemStatus.ACTIVE);
+
+        if (updatedRows == 0) {
+            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
+        }
+
         bidService.closeBids(itemId);
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
-        return new BuyNowResponse(itemId, buyerId, item.getBuyNowPrice(), item.getStatus());
+        return new BuyNowResponse(itemId, buyerId, item.getBuyNowPrice(), ItemStatus.BUY_NOW_CLOSED);
     }
 
     private List<ItemMedia> toItemMedias(List<UploadedMedia> uploadedMedias, Item item) {

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -6,7 +6,6 @@ import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.support.IntegrationTestSupport;
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,8 +67,12 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
                     startLatch.await();
                     bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(bidPrice));
                     successCount.incrementAndGet();
-                } catch (Exception e) {
-                    failCount.incrementAndGet();
+                } catch (BusinessException e) {
+                    if (e.getErrorCode() == ErrorCode.INVALID_BID_PRICE) {
+                        failCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 } finally {
                     doneLatch.countDown();
                 }
@@ -106,6 +108,7 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
                     startLatch.await();
                     bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(bidPrice));
                 } catch (Exception e) {
+                    // 경합에서 밀린 입찰 실패는 예상된 결과 — 최종 상태(최고가 반영)만 검증
                 } finally {
                     doneLatch.countDown();
                 }
@@ -172,21 +175,4 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
         assertThat(reloaded.getCurrentPrice()).isEqualTo(before);
     }
 
-    private static User newUser(String email, String nickname) {
-        return new User(email, "password", nickname, "address");
-    }
-
-    private static Item newItem(User seller) {
-        return Item.create(
-                seller,
-                "테스트 상품",
-                "설명",
-                "카테고리",
-                ItemCondition.GOOD,
-                "브랜드",
-                1_000L,
-                1_000_000L,
-                LocalDateTime.now().plusDays(1)
-        );
-    }
 }

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
@@ -1,0 +1,105 @@
+package io.wisoft.ignoa_api.item.service;
+
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.support.IntegrationTestSupport;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ItemBuyNowTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Autowired
+    private ItemCommandService itemCommandService;
+
+    @AfterEach
+    void tearDown() {
+        itemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void 정상적인_즉시구매는_상품을_BUY_NOW_CLOSED_상태로_마감한다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "seller"));
+        User buyer = userRepository.save(newUser("buyer@test.com", "buyer"));
+        Item item = itemRepository.save(newItem(seller));
+
+        // When
+        BuyNowResponse response = itemCommandService.buyNowItem(item.getId(), buyer.getId());
+
+        // Then
+        assertThat(response.status()).isEqualTo(ItemStatus.BUY_NOW_CLOSED);
+
+        Item reloaded = itemRepository.findById(item.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ItemStatus.BUY_NOW_CLOSED);
+    }
+
+    @Test
+    void 동시에_즉시구매하면_한_건만_성공하고_나머지는_실패한다() throws InterruptedException {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "seller"));
+        Item item = itemRepository.save(newItem(seller));
+
+        int threadCount = 10;
+
+        List<Long> buyerIds = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            buyerIds.add(userRepository.save(
+                    newUser("buyer" + i + "@test.com", "buyer" + i)).getId());
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // When
+        for (Long buyerId : buyerIds) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    itemCommandService.buyNowItem(item.getId(), buyerId);
+                    successCount.incrementAndGet();
+                } catch (BusinessException e) {
+                    if (e.getErrorCode() == ErrorCode.AUCTION_ALREADY_CLOSED) {
+                        failCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // Then
+        assertThat(successCount.get()).isOne();
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+    }
+}

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
@@ -1,7 +1,6 @@
 package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.support.IntegrationTestSupport;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -62,23 +60,5 @@ class ItemDynamicUpdateTest extends IntegrationTestSupport {
         // Then
         Item reloaded = itemRepository.findById(itemId).orElseThrow();
         assertThat(reloaded.getCurrentPrice()).isEqualTo(raised);
-    }
-
-    private static User newUser(String email, String nickname) {
-        return new User(email, "password", nickname, "address");
-    }
-
-    private static Item newItem(User seller) {
-        return Item.create(
-                seller,
-                "테스트 상품",
-                "설명",
-                "카테고리",
-                ItemCondition.GOOD,
-                "브랜드",
-                1_000L,
-                1_000_000L,
-                LocalDateTime.now().plusDays(1)
-        );
     }
 }

--- a/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
+++ b/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
@@ -1,6 +1,9 @@
 package io.wisoft.ignoa_api.support;
 
 
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemCondition;
+import io.wisoft.ignoa_api.user.entity.User;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
@@ -10,6 +13,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.LocalDateTime;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -32,5 +37,23 @@ public abstract class IntegrationTestSupport {
         registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
         registry.add("spring.data.redis.port",
                 () -> REDIS_CONTAINER.getMappedPort(6379));
+    }
+
+    protected User newUser(String email, String nickname) {
+        return new User(email, "password", nickname, "address");
+    }
+
+    protected Item newItem(User seller) {
+        return Item.create(
+                seller,
+                "테스트 상품",
+                "설명",
+                "카테고리",
+                ItemCondition.GOOD,
+                "브랜드",
+                1_000L,
+                1_000_000L,
+                LocalDateTime.now().plusDays(1)
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #91 
- related: #87 

---

## 📝 작업 내용 (Description)

> 즉시구매(buyNow)를 fail-open으로 승격하려면 락 없이도 정합성이 보장되어야 한다. 기존 `isActive()` 체크 후 dirty checking 방식은 락을 제거하면 동시 buyNow·입찰 교차에서 문제가 생긴다. 이를 조건부 UPDATE 기반으로 전환해 DB 차원에서 보장한다.

### 1. 마감 상태 전이를 조건부 UPDATE로 전환
- `buyNowIfActive`: `WHERE status=ACTIVE` 조건부 UPDATE로 마감
- 0행이면 `AUCTION_ALREADY_CLOSED` 처리 → 동시 buyNow에서 한 건만 성공
- 벌크 UPDATE로 stale해진 응답 status는 상수(`BUY_NOW_CLOSED`)로 구성

### 2. 테스트
- 정상 buyNow 마감 / 동시 buyNow 한 건만 성공 검증

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [x] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

**완료조건 검증**

| 완료조건 | 검증 방식 |
|---|---|
| 동시 buyNow → 한 건만 성공, 나머지 AUCTION_ALREADY_CLOSED | 조건부 UPDATE 행 잠금 직렬화 + 0행 게이트 (ItemBuyNowTest 동시성) |
| buyNow↔입찰 교차 Orphan Bid 미발생 | 전용 테스트 없이 조합으로 보장: buyNow status 확정(ItemBuyNowTest) + 마감 상품 입찰 차단(#84). 실제 교차 재현은 flaky로 제외 |
| 마감 후 응답 상태 정확 (stale 아님) | 응답을 상수 BUY_NOW_CLOSED로 구성, response.status() 단언 |
| build & 테스트 통과 | 전체 ./gradlew test 통과 |

**참고**
- 공용 픽스처(`newUser`/`newItem`)를 `IntegrationTestSupport`로 이관
- 동시 입찰 테스트 실패 검증을 INVALID_BID_PRICE로 정밀화 (테스트 정리 포함)