### PR TITLE
feat: 즉시구매 fail-open 적용 (Redis 장애 시 즉시구매 가용성 확보)

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -1,5 +1,6 @@
 package io.wisoft.ignoa_api.item.service;
 
+import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
@@ -71,11 +72,16 @@ public class ItemFacade {
     }
 
     public BuyNowResponse buyNowItem(Long itemId, Long buyerId) {
-        return distributedLock.executeWithLock(
-                ItemLockKey.of(itemId),
-                BUY_NOW_WAIT_MILLIS,
-                () -> itemCommandService.buyNowItem(itemId, buyerId)
-        );
+        try {
+            return distributedLock.executeWithLock(
+                    ItemLockKey.of(itemId),
+                    BUY_NOW_WAIT_MILLIS,
+                    () -> itemCommandService.buyNowItem(itemId, buyerId)
+            );
+        } catch (LockInfrastructureException e) {
+            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 즉시구매 진행 itemId={}, buyerId={}", itemId, buyerId, e);
+            return itemCommandService.buyNowItem(itemId, buyerId);
+        }
     }
 
     private void uploadFiles(List<MultipartFile> files, List<UploadedMedia> uploadedMedias) {

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
@@ -1,0 +1,79 @@
+package io.wisoft.ignoa_api.item.service;
+
+import io.wisoft.ignoa_api.global.exception.BusinessException;
+import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
+import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
+import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
+import io.wisoft.ignoa_api.item.support.ItemLockKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ItemFacadeTest {
+
+    @Mock
+    RedissonDistributedLock redissonDistributedLock;
+
+    @Mock
+    ItemCommandService itemCommandService;
+
+    @InjectMocks
+    ItemFacade itemFacade;
+
+    @Test
+    void Redis_인프라_장애가_발생하면_락_없이_즉시구매를_진행한다() {
+        // Given
+        long itemId = 1L;
+        long buyerId = 2L;
+        BuyNowResponse expected = mock(BuyNowResponse.class);
+
+        given(redissonDistributedLock.executeWithLock(
+                eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
+                .willThrow(new LockInfrastructureException("Redis 장애", new RuntimeException()));
+
+        given(itemCommandService.buyNowItem(itemId, buyerId)).willReturn(expected);
+
+        // When
+        BuyNowResponse response = itemFacade.buyNowItem(itemId, buyerId);
+
+        // Then
+        assertThat(response).isEqualTo(expected);
+        verify(itemCommandService).buyNowItem(itemId, buyerId);
+    }
+
+    @Test
+    void 락_획득이_타임아웃되면_fast_fail되어_예외를_전파한다() {
+        // Given
+        long itemId = 1L;
+        long buyerId = 2L;
+
+        given(redissonDistributedLock.executeWithLock(
+                eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
+                .willThrow(new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED));
+
+        // When
+        BusinessException exception = catchThrowableOfType(
+                BusinessException.class,
+                () -> itemFacade.buyNowItem(itemId, buyerId)
+        );
+
+        // Then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.LOCK_ACQUISITION_FAILED);
+        verify(itemCommandService, never()).buyNowItem(itemId, buyerId);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #88 
- related: #91

---

## 📝 작업 내용 (Description)

> 선행 작업에서 조건부 UPDATE(buyNowIfActive)를 통해 buyNow의 정합성을 DB 차원에서 보장함으로써, 입찰(#84)과 동일하게 즉시구매에도 fail-open을 적용했습니다.

### 1. ItemFacade.buyNowItem fail-open 적용
- Redis 인프라 장애(`LockInfrastructureException`)만 catch → WARN 로그 후 락 없이 재실행
- 락 획득 타임아웃(`LOCK_ACQUISITION_FAILED`)은 전파(fast-fail)

### 2. 테스트
- `ItemFacadeTest`: 인프라 장애 fail-open / 타임아웃 fast-fail 검증

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [x] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- 현재 Redis fail-open 적용은 입찰, 즉시구매 뿐
- 수정·삭제 경로는 fail-closed 유지