### PR TITLE
refactor(bid): closeBids를 벌크 UPDATE로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,12 @@ db/
 
 # AI
 CLAUDE.md
+AGENTS.md
 .claude
+.codex
+.agents
+
+# Docs
 docs/
 
 # K6

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -40,9 +40,6 @@ public class AuctionCloseService {
             return;
         }
 
-        // 입찰 개수만큼 개별 UPDATE O(n)이 발생한다.
-        // 대량 입찰/동시 마감으로 write burst가 커지면 벌크 UPDATE로 전환 검토가 필요하다.
-        // (현재 트래픽에선 불필요)
         bidService.closeBids(itemId);
         Bid topBid = bid.get();
         topBid.closeAsWon();

--- a/src/main/java/io/wisoft/ignoa_api/bid/entity/Bid.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/entity/Bid.java
@@ -44,8 +44,4 @@ public class Bid extends BaseEntity {
     public void closeAsWon() {
         this.status = BidStatus.WON;
     }
-
-    public void closeAsLost() {
-        this.status = BidStatus.LOST;
-    }
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -3,6 +3,7 @@ package io.wisoft.ignoa_api.bid.repository;
 import io.wisoft.ignoa_api.bid.entity.Bid;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -42,4 +43,13 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     List<Bid> findByItemId(Long itemId);
 
     boolean existsByItemId(Long itemId);
+
+    @Modifying
+    @Query("""
+            UPDATE Bid b
+            SET b.status = 'LOST'
+            WHERE b.item.id = :itemId
+              AND b.status = 'ACTIVE'
+            """)
+    int closeActiveBidsAsLost(@Param("itemId") Long itemId);
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -7,7 +7,6 @@ import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.event.BidPlaceEvent;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
-import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemReader;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -58,7 +57,7 @@ public class BidService {
             throw new BusinessException(ErrorCode.BID_PRICE_EXCEEDS_BUY_NOW);
         }
 
-        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, ItemStatus.ACTIVE);
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice);
 
         if (updatedRows == 0) {
             resolveBidFailure(item);
@@ -73,10 +72,7 @@ public class BidService {
 
     @Transactional
     public void closeBids(Long itemId) {
-        // TODO
-        // 입찰 N개 SELECT, 각각 Dirty → flush 시 UPDATE N번
-        bidRepository.findByItemId(itemId)
-                .forEach(Bid::closeAsLost);
+        bidRepository.closeActiveBidsAsLost(itemId);
     }
 
     public List<BidHistory> getBids(Long itemId) {

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -72,22 +72,19 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("""
             UPDATE Item i
             SET i.currentPrice = :price
-            WHERE i.id = :id 
+            WHERE i.id = :id
                 AND i.currentPrice < :price
-                AND i.status = :status
+                AND i.status = 'ACTIVE'
             """)
-    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price, @Param("status") ItemStatus status);
+    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price);
 
     @Modifying
     @Query("""
             UPDATE Item i
-            SET i.status = :closedStatus,
+            SET i.status = 'BUY_NOW_CLOSED',
                 i.winner = :winner
             WHERE i.id = :id 
-                AND i.status = :activeStatus 
+                AND i.status = 'ACTIVE' 
             """)
-    int buyNowIfActive(@Param("id") Long id,
-                       @Param("winner") User winner,
-                       @Param("closedStatus") ItemStatus closedStatus,
-                       @Param("activeStatus") ItemStatus activeStatus);
+    int buyNowIfActive(@Param("id") Long id, @Param("winner") User winner);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -144,8 +144,7 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        int updatedRows = itemRepository.buyNowIfActive(
-                itemId, user, ItemStatus.BUY_NOW_CLOSED, ItemStatus.ACTIVE);
+        int updatedRows = itemRepository.buyNowIfActive(itemId, user);
 
         if (updatedRows == 0) {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -6,7 +6,6 @@ import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.support.IntegrationTestSupport;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -167,7 +166,7 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
 
         // When
         int updatedRows = itemRepository.raiseCurrentPriceIfHigher(
-                item.getId(), bidPrice, ItemStatus.ACTIVE);
+                item.getId(), bidPrice);
 
         // Then
         assertThat(updatedRows).isZero();

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
@@ -1,7 +1,6 @@
 package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.support.IntegrationTestSupport;
 import io.wisoft.ignoa_api.user.entity.User;
@@ -51,7 +50,7 @@ class ItemDynamicUpdateTest extends IntegrationTestSupport {
         // When
         Item item = entityManager.find(Item.class, itemId);
 
-        itemRepository.raiseCurrentPriceIfHigher(itemId, raised, ItemStatus.ACTIVE);
+        itemRepository.raiseCurrentPriceIfHigher(itemId, raised);
 
         item.buyNow(buyer);
         entityManager.flush();


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #92 

---

## 📝 작업 내용 (Description)

### 1. closeBids를 벌크 UPDATE로 전환 (이슈 본체)

- 기존: 입찰 N개를 조회 후 `forEach(Bid::closeAsLost)`
  - dirty checking으로 SELECT 1 + UPDATE N번 발생
- 변경: `BidRepository.closeActiveBidsAsLost` (@Modifying 벌크 쿼리) 추가로 UPDATE 1회로 전환
- 엔티티 N개를 영속성 컨텍스트에 로딩하는 비용 제거
- 미사용이 된 `Bid.closeAsLost()` 제거, `AuctionCloseService`의 낡은 O(n) 관련 주석 정리

### 2. 벌크 UPDATE의 고정 status를 리터럴로 통일 (부수 작업)
- `raiseCurrentPriceIfHigher`, `buyNowIfActive`가 고정 status를 파라미터로 받던 것을 문자열 리터럴로 변경
- 조회 쿼리 및 신규 `closeActiveBidsAsLost`와 동일한 컨벤션으로 맞춤 (시그니처 간결화)

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

리뷰어에게 전달할 내용이 있다면 작성해주세요. (스크린샷, 논의가 필요한 지점 등)
