### PR TITLE
fix(item): 즉시구매 조건부 UDPATE에 가격 가드 추가

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     ITEM_WITH_BID_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "입찰 이력이 있는 상품은 삭제할 수 없습니다."),
     END_AT_TOO_SOON(HttpStatus.BAD_REQUEST, "경매 종료 시간은 최소 1일 이후여야 합니다."),
     END_AT_TOO_LATE(HttpStatus.BAD_REQUEST, "경매 종료 시간은 최대 7일 이내여야 합니다."),
+    PRICE_CHANGED(HttpStatus.CONFLICT, "즉시구매가가 변경되었습니다. 최신 가격을 확인 후 다시 시도해주세요."),
 
     // Bid
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),

--- a/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/controller/ItemController.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.item.controller;
 
 import io.wisoft.ignoa_api.global.common.SliceResponse;
+import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemPreviewRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
@@ -88,9 +89,10 @@ public class ItemController {
     @PostMapping("/{itemId}/buy-now")
     public ResponseEntity<ApiResponse<BuyNowResponse>> buyNowItem(
             @PathVariable Long itemId,
-            @AuthenticationPrincipal Long buyerId
+            @AuthenticationPrincipal Long buyerId,
+            @Valid @RequestBody ItemBuyNowRequest request
     ) {
-        BuyNowResponse data = itemFacade.buyNowItem(itemId, buyerId);
+        BuyNowResponse data = itemFacade.buyNowItem(itemId, buyerId, request);
         ApiResponse<BuyNowResponse> response = ApiResponse.of(data, "상품을 즉시 구매하였습니다.");
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemBuyNowRequest.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/dto/request/ItemBuyNowRequest.java
@@ -1,0 +1,11 @@
+package io.wisoft.ignoa_api.item.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ItemBuyNowRequest(
+        @NotNull(message = "즉시 구매가는 필수입니다")
+        @Min(value = 0, message = "즉시 구매가는 0원 이상이어야 합니다")
+        Long buyNowPrice
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -84,7 +84,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             SET i.status = 'BUY_NOW_CLOSED',
                 i.winner = :winner
             WHERE i.id = :id 
-                AND i.status = 'ACTIVE' 
+                AND i.status = 'ACTIVE'
+                AND i.buyNowPrice = :buyNowPrice             
             """)
-    int buyNowIfActive(@Param("id") Long id, @Param("winner") User winner);
+    int buyNowIfActive(@Param("id") Long id, @Param("winner") User winner, @Param("buyNowPrice") Long buyNowPrice);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -6,6 +6,7 @@ import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.bid.service.BidService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
 import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
@@ -19,6 +20,9 @@ import io.wisoft.ignoa_api.item.service.dto.UploadedMedia;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -41,6 +45,7 @@ public class ItemCommandService {
 
     private final ItemReader itemReader;
     private final ApplicationEventPublisher eventPublisher;
+    private final EntityManager entityManager;
 
     private final ItemRepository itemRepository;
     private final WishRepository wishRepository;
@@ -132,7 +137,7 @@ public class ItemCommandService {
         return new ItemIdResponse(item.getId());
     }
 
-    public BuyNowResponse buyNowItem(Long itemId, Long buyerId) {
+    public BuyNowResponse buyNowItem(Long itemId, Long buyerId, ItemBuyNowRequest request) {
         Item item = itemReader.getById(itemId);
         User user = userQueryService.findById(buyerId);
 
@@ -144,16 +149,30 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        int updatedRows = itemRepository.buyNowIfActive(itemId, user);
+        int updatedRows = itemRepository.buyNowIfActive(itemId, user, request.buyNowPrice());
 
         if (updatedRows == 0) {
-            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
+            resolveBuyNowFailure(item);
         }
 
         bidService.closeBids(itemId);
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
-        return new BuyNowResponse(itemId, buyerId, item.getBuyNowPrice(), ItemStatus.BUY_NOW_CLOSED);
+        return new BuyNowResponse(itemId, buyerId, request.buyNowPrice(), ItemStatus.BUY_NOW_CLOSED);
+    }
+
+    private void resolveBuyNowFailure(Item item) {
+        try {
+            entityManager.refresh(item, LockModeType.PESSIMISTIC_READ);
+        } catch (EntityNotFoundException e) {
+            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
+        }
+
+        if (item.isClosed()) {
+            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
+        }
+
+        throw new BusinessException(ErrorCode.PRICE_CHANGED);
     }
 
     private List<ItemMedia> toItemMedias(List<UploadedMedia> uploadedMedias, Item item) {

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -5,6 +5,7 @@ import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
 import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
+import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
 import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
@@ -71,16 +72,16 @@ public class ItemFacade {
         );
     }
 
-    public BuyNowResponse buyNowItem(Long itemId, Long buyerId) {
+    public BuyNowResponse buyNowItem(Long itemId, Long buyerId, ItemBuyNowRequest request) {
         try {
             return distributedLock.executeWithLock(
                     ItemLockKey.of(itemId),
                     BUY_NOW_WAIT_MILLIS,
-                    () -> itemCommandService.buyNowItem(itemId, buyerId)
+                    () -> itemCommandService.buyNowItem(itemId, buyerId, request)
             );
         } catch (LockInfrastructureException e) {
             log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 즉시구매 진행 itemId={}, buyerId={}", itemId, buyerId, e);
-            return itemCommandService.buyNowItem(itemId, buyerId);
+            return itemCommandService.buyNowItem(itemId, buyerId, request);
         }
     }
 

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
@@ -45,9 +46,10 @@ class ItemBuyNowTest extends IntegrationTestSupport {
         User seller = userRepository.save(newUser("seller@test.com", "seller"));
         User buyer = userRepository.save(newUser("buyer@test.com", "buyer"));
         Item item = itemRepository.save(newItem(seller));
+        ItemBuyNowRequest request = new ItemBuyNowRequest(item.getBuyNowPrice());
 
         // When
-        BuyNowResponse response = itemCommandService.buyNowItem(item.getId(), buyer.getId());
+        BuyNowResponse response = itemCommandService.buyNowItem(item.getId(), buyer.getId(), request);
 
         // Then
         assertThat(response.status()).isEqualTo(ItemStatus.BUY_NOW_CLOSED);
@@ -61,6 +63,7 @@ class ItemBuyNowTest extends IntegrationTestSupport {
         // Given
         User seller = userRepository.save(newUser("seller@test.com", "seller"));
         Item item = itemRepository.save(newItem(seller));
+        ItemBuyNowRequest request = new ItemBuyNowRequest(item.getBuyNowPrice());
 
         int threadCount = 10;
 
@@ -81,7 +84,7 @@ class ItemBuyNowTest extends IntegrationTestSupport {
             executor.submit(() -> {
                 try {
                     startLatch.await();
-                    itemCommandService.buyNowItem(item.getId(), buyerId);
+                    itemCommandService.buyNowItem(item.getId(), buyerId, request);
                     successCount.incrementAndGet();
                 } catch (BusinessException e) {
                     if (e.getErrorCode() == ErrorCode.AUCTION_ALREADY_CLOSED) {

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
@@ -4,6 +4,7 @@ import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
+import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import org.junit.jupiter.api.Test;
@@ -40,20 +41,21 @@ class ItemFacadeTest {
         // Given
         long itemId = 1L;
         long buyerId = 2L;
+        ItemBuyNowRequest request = new ItemBuyNowRequest(10_000L);
         BuyNowResponse expected = mock(BuyNowResponse.class);
 
         given(redissonDistributedLock.executeWithLock(
                 eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
                 .willThrow(new LockInfrastructureException("Redis 장애", new RuntimeException()));
 
-        given(itemCommandService.buyNowItem(itemId, buyerId)).willReturn(expected);
+        given(itemCommandService.buyNowItem(itemId, buyerId, request)).willReturn(expected);
 
         // When
-        BuyNowResponse response = itemFacade.buyNowItem(itemId, buyerId);
+        BuyNowResponse response = itemFacade.buyNowItem(itemId, buyerId, request);
 
         // Then
         assertThat(response).isEqualTo(expected);
-        verify(itemCommandService).buyNowItem(itemId, buyerId);
+        verify(itemCommandService).buyNowItem(itemId, buyerId, request);
     }
 
     @Test
@@ -61,6 +63,7 @@ class ItemFacadeTest {
         // Given
         long itemId = 1L;
         long buyerId = 2L;
+        ItemBuyNowRequest request = new ItemBuyNowRequest(10_000L);
 
         given(redissonDistributedLock.executeWithLock(
                 eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
@@ -69,11 +72,11 @@ class ItemFacadeTest {
         // When
         BusinessException exception = catchThrowableOfType(
                 BusinessException.class,
-                () -> itemFacade.buyNowItem(itemId, buyerId)
+                () -> itemFacade.buyNowItem(itemId, buyerId, request)
         );
 
         // Then
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.LOCK_ACQUISITION_FAILED);
-        verify(itemCommandService, never()).buyNowItem(itemId, buyerId);
+        verify(itemCommandService, never()).buyNowItem(itemId, buyerId, request);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #93 
- related: #95

---

## 📝 작업 내용 (Description)

> `buyNow`는 요청에 가격이 없고 서버의 `item.getBuyNowPrice()`로만 처리해, 구매자가 상품을 조회한 뒤 판매자가 즉시구매가를 변경하면 구매자가 확인한 값과 다른 가격에 거래가 성사될 수 있었습니다.

> 이를 "구매자가 확인한 가격 == 실제 확정 가격"을 조건부 UPDATE로 원자적으로 보장하도록 수정했습니다.

  ### 1. 가격 가드 추가
  - `buyNow` 요청 DTO(`ItemBuyNowRequest`) 신설 — 구매자가 확인한 `buyNowPrice` 전달
  - `buyNowIfActive` WHERE에 `AND i.buyNowPrice = :buyNowPrice` 추가 → 가격이 변경되어 0행 갱신되면 실패
  - fail-open 경로에도 동일하게 `request`를 전달해 락과 무관하게 가드 적용

  ### 2. 실패 원인 구분
  - 0행 갱신 시 `resolveBuyNowFailure`로 원인 판별
    - 마감(status) → `AUCTION_ALREADY_CLOSED`
    - 가격 변경 → `PRICE_CHANGED` (신규 ErrorCode)
  - 최신 상태 확인을 위해 `EntityManager.refresh(item, PESSIMISTIC_READ)` 사용
  - (REPEATABLE READ 스냅샷을 벗어나 최신 커밋값을 읽기 위함, `resolveBidFailure`와 동일 패턴)

  ### 3. 테스트 갱신
  - 시그니처 변경(`buyNowItem(itemId, buyerId, request)`)에 맞춰
    `ItemBuyNowTest`, `ItemFacadeTest` 호출부 수정

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- 현재 결제 로직은 미구현 상태로, `buyNowPrice`는 응답 표시용으로만 쓰입니다.
- 실 피해는 아직 없으나 결제 도입 시 곧바로 오결제로 이어지므로 **선행 방어**로 처리했습니다.