### PR TITLE
refactor: 경매 마감 동시성 정합성 DB 보장 및 fail-open 적용

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionTtlListener.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/listener/AuctionTtlListener.java
@@ -12,15 +12,15 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class AuctionTtlListener {
 
-    private final AuctionTtlService auctionRedisService;
+    private final AuctionTtlService auctionTtlService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onAuctionRegistered(AuctionRegisteredEvent event) {
-        auctionRedisService.registerTtl(event.itemId(), event.endAt());
+        auctionTtlService.registerTtl(event.itemId(), event.endAt());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onAuctionClosed(AuctionClosedEvent event) {
-        auctionRedisService.deleteTtl(event.itemId());
+        auctionTtlService.deleteTtl(event.itemId());
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
@@ -1,14 +1,12 @@
 package io.wisoft.ignoa_api.auction.scheduler;
 
 import io.wisoft.ignoa_api.auction.service.AuctionCloseFacade;
-import io.wisoft.ignoa_api.auction.service.AuctionCloseService;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +14,6 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuctionCloseJob {
 
     private final AuctionCloseFacade auctionCloseFacade;

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseScheduler.java
@@ -14,7 +14,7 @@ public class AuctionCloseScheduler {
 
     private final AuctionCloseJob auctionCloseJob;
 
-    @Scheduled(cron = "0 */5 * * * *")
+    @Scheduled(cron = "0 */1 * * * *")
     @SchedulerLock(name = "auctionCloseScheduler")
     public void closeExpiredAuctions() {
         log.info("경매 마감 스케줄러 실행");

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseFacade.java
@@ -1,11 +1,13 @@
 package io.wisoft.ignoa_api.auction.service;
 
+import io.wisoft.ignoa_api.global.infra.lock.LockInfrastructureException;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuctionCloseFacade {
@@ -16,11 +18,16 @@ public class AuctionCloseFacade {
     private final RedissonDistributedLock distributedLock;
 
     public void closeAuction(Long itemId) {
-        distributedLock.executeWithLock(
-                ItemLockKey.of(itemId),
-                WAIT_TIME_MILLIS,
-                () -> auctionCloseService.closeAuction(itemId)
-        );
+        try {
+            distributedLock.executeWithLock(
+                    ItemLockKey.of(itemId),
+                    WAIT_TIME_MILLIS,
+                    () -> auctionCloseService.closeAuction(itemId)
+            );
+        } catch (LockInfrastructureException e) {
+            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 마감을 진행 itemId={}", itemId, e);
+            auctionCloseService.closeAuction(itemId);
+        }
     }
 }
 

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -1,18 +1,13 @@
 package io.wisoft.ignoa_api.auction.service;
 
-import io.wisoft.ignoa_api.bid.entity.Bid;
-import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.bid.service.BidService;
-import io.wisoft.ignoa_api.item.entity.Item;
-import io.wisoft.ignoa_api.item.service.ItemReader;
-import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -20,35 +15,17 @@ import java.util.Optional;
 public class AuctionCloseService {
 
     private final BidService bidService;
-    private final BidRepository bidRepository;
-    private final ItemReader itemReader;
+    private final ItemRepository itemRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void closeAuction(Long itemId) {
-        Item item = itemReader.getById(itemId);
-
-        if (item.isClosed()) {
-            log.info("[중복 마감 방지] 이미 마감된 경매 itemId={} status={}", itemId, item.getStatus());
+        int closedRows = itemRepository.closeIfActive(itemId);
+        if (closedRows == 0) {
+            log.info("[중복 마감 방지] 이미 마감된 경매 itemId={}", itemId);
             return;
         }
 
-        Optional<Bid> bid = bidRepository.findTopByItemIdOrderByPriceDesc(itemId);
-
-        if (bid.isEmpty()) {
-            log.info("[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
-            item.closeWithoutBid();
-            return;
-        }
-
-        // 조건부 UPDATE 했고 이때부터 X-LOCk 잡힘
-        // 이때 잡히는 락을 Bid Row에 잡히느거지? Item row가 아니라..?
-        bidRepository.closeActiveBidsAsLost(itemId);
-
-        bidService.closeBids(itemId);
-        Bid topBid = bid.get();
-        topBid.closeAsWon();
-
-        User winner = topBid.getBidder();
-        item.closeWithWinner(winner);
+        boolean sold = bidService.settleBids(itemId);
+        log.info(sold ? "[낙찰] 경매 마감 itemId={}" : "[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -40,6 +40,10 @@ public class AuctionCloseService {
             return;
         }
 
+        // 조건부 UPDATE 했고 이때부터 X-LOCk 잡힘
+        // 이때 잡히는 락을 Bid Row에 잡히느거지? Item row가 아니라..?
+        bidRepository.closeActiveBidsAsLost(itemId);
+
         bidService.closeBids(itemId);
         Bid topBid = bid.get();
         topBid.closeAsWon();

--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -54,14 +54,13 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     int markLosingBids(@Param("itemId") Long itemId);
 
     @Modifying
-    @Query("""
-            UPDATE Bid b
-            SET b.status = 'WON'
-            WHERE b.item.id = :itemId
-             AND b.status = 'ACTIVE'
-             AND b.price = (SELECT MAX(b2.price) FROM Bid b2
-                            WHERE b2.item.id = :itemId
-                                AND b2.status = 'ACTIVE')  
-            """)
+    @Query(value = """
+            UPDATE bids
+            SET status = 'WON'
+            WHERE item_id = :itemId
+             AND status = 'ACTIVE'
+            ORDER BY price DESC, id DESC
+            LIMIT 1
+            """, nativeQuery = true)
     int markWinningBid(@Param("itemId") Long itemId);
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/repository/BidRepository.java
@@ -51,5 +51,17 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
             WHERE b.item.id = :itemId
               AND b.status = 'ACTIVE'
             """)
-    int closeActiveBidsAsLost(@Param("itemId") Long itemId);
+    int markLosingBids(@Param("itemId") Long itemId);
+
+    @Modifying
+    @Query("""
+            UPDATE Bid b
+            SET b.status = 'WON'
+            WHERE b.item.id = :itemId
+             AND b.status = 'ACTIVE'
+             AND b.price = (SELECT MAX(b2.price) FROM Bid b2
+                            WHERE b2.item.id = :itemId
+                                AND b2.status = 'ACTIVE')  
+            """)
+    int markWinningBid(@Param("itemId") Long itemId);
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.bid.service;
 
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
+
 import io.wisoft.ignoa_api.bid.dto.response.BidHistory;
 import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
 import io.wisoft.ignoa_api.bid.entity.Bid;
@@ -30,8 +31,10 @@ public class BidService {
 
     private final UserQueryService userQueryService;
     private final ItemReader itemReader;
+
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
+
     private final ApplicationEventPublisher eventPublisher;
     private final EntityManager entityManager;
 
@@ -71,8 +74,13 @@ public class BidService {
     }
 
     @Transactional
-    public void closeBids(Long itemId) {
-        bidRepository.closeActiveBidsAsLost(itemId);
+    public boolean settleBids(Long itemId) {
+        if (bidRepository.markWinningBid(itemId) == 0) {
+            return false;
+        }
+
+        bidRepository.markLosingBids(itemId);
+        return true;
     }
 
     public List<BidHistory> getBids(Long itemId) {

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -57,7 +57,7 @@ public class BidService {
             throw new BusinessException(ErrorCode.BID_PRICE_EXCEEDS_BUY_NOW);
         }
 
-        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice);
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, bidder);
 
         if (updatedRows == 0) {
             resolveBidFailure(item);

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -31,8 +31,8 @@ public class Item extends BaseEntity {
     private User seller;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "winner_id")
-    private User winner;
+    @JoinColumn(name = "highest_bidder_id")
+    private User highestBidder;
 
     @Column(nullable = false)
     private String title;
@@ -131,8 +131,8 @@ public class Item extends BaseEntity {
         return bidPrice >= this.buyNowPrice;
     }
 
-    public void buyNow(User winner) {
-        this.winner = winner;
+    public void buyNow(User buyer) {
+        this.highestBidder = buyer;
         this.status = ItemStatus.BUY_NOW_CLOSED;
     }
 
@@ -141,7 +141,7 @@ public class Item extends BaseEntity {
     }
 
     public void closeWithWinner(User winner) {
-        this.winner = winner;
+        this.highestBidder = winner;
         this.status = ItemStatus.BID_CLOSED;
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -82,10 +82,10 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("""
             UPDATE Item i
             SET i.status = 'BUY_NOW_CLOSED',
-                i.winner = :winner
-            WHERE i.id = :id 
+                i.highestBidder = :buyer
+            WHERE i.id = :id
                 AND i.status = 'ACTIVE'
-                AND i.buyNowPrice = :buyNowPrice             
+                AND i.buyNowPrice = :buyNowPrice
             """)
-    int buyNowIfActive(@Param("id") Long id, @Param("winner") User winner, @Param("buyNowPrice") Long buyNowPrice);
+    int buyNowIfActive(@Param("id") Long id, @Param("buyer") User buyer, @Param("buyNowPrice") Long buyNowPrice);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -90,4 +90,13 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
                 AND i.buyNowPrice = :buyNowPrice
             """)
     int buyNowIfActive(@Param("id") Long id, @Param("buyer") User buyer, @Param("buyNowPrice") Long buyNowPrice);
+
+    @Modifying
+    @Query("""
+            UPDATE Item i 
+            SET i.status = CASE WHEN i.highestBidder IS NULL THEN 'NO_BID_CLOSED' ELSE 'BID_CLOSED' END
+            WHERE i.id = :id
+                AND i.status = 'ACTIVE'                                    
+            """)
+    int closeIfActive(@Param("id") Long id);
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -71,12 +72,13 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Modifying
     @Query("""
             UPDATE Item i
-            SET i.currentPrice = :price
+            SET i.currentPrice = :price,
+                i.highestBidder = :highestBidder
             WHERE i.id = :id
                 AND i.currentPrice < :price
                 AND i.status = 'ACTIVE'
             """)
-    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price);
+    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price, @Param("highestBidder") User highestBidder);
 
     @Modifying
     @Query("""

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -3,7 +3,6 @@ package io.wisoft.ignoa_api.item.service;
 import io.wisoft.ignoa_api.auction.event.AuctionClosedEvent;
 import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
-import io.wisoft.ignoa_api.bid.service.BidService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
@@ -41,7 +40,6 @@ public class ItemCommandService {
     private final ItemMediaService itemMediaService;
     private final ItemQueryService itemQueryService;
     private final UserQueryService userQueryService;
-    private final BidService bidService;
 
     private final ItemReader itemReader;
     private final ApplicationEventPublisher eventPublisher;
@@ -149,13 +147,13 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        int updatedRows = itemRepository.buyNowIfActive(itemId, user, request.buyNowPrice());
+        int buyNowRows = itemRepository.buyNowIfActive(itemId, user, request.buyNowPrice());
 
-        if (updatedRows == 0) {
+        if (buyNowRows == 0) {
             resolveBuyNowFailure(item);
         }
 
-        bidService.closeBids(itemId);
+        bidRepository.markLosingBids(itemId);
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
         return new BuyNowResponse(itemId, buyerId, request.buyNowPrice(), ItemStatus.BUY_NOW_CLOSED);

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -156,6 +156,7 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
     void 마감된_상품은_가격_조건을_만족해도_status_가드로_갱신되지_않는다() {
         // Given
         User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User bidder = userRepository.save(newUser("bidder@test.com", "입찰자"));
         Item item = itemRepository.save(newItem(seller));
 
         long before = item.getCurrentPrice();
@@ -166,7 +167,7 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
 
         // When
         int updatedRows = itemRepository.raiseCurrentPriceIfHigher(
-                item.getId(), bidPrice);
+                item.getId(), bidPrice, bidder);
 
         // Then
         assertThat(updatedRows).isZero();

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemDynamicUpdateTest.java
@@ -50,7 +50,7 @@ class ItemDynamicUpdateTest extends IntegrationTestSupport {
         // When
         Item item = entityManager.find(Item.class, itemId);
 
-        itemRepository.raiseCurrentPriceIfHigher(itemId, raised);
+        itemRepository.raiseCurrentPriceIfHigher(itemId, raised, buyer);
 
         item.buyNow(buyer);
         entityManager.flush();


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #103

---

## 📝 작업 내용 (Description)

- 경매 마감의 정합성을 Redis 분산 락 의존에서 **DB 레벨(조건부 UPDATE + 승자 선확정)** 으로 옮기고, 그 위에 **Fail-Open** 을 적용했습니다.
- `isClosed()` 읽기 검사 + Dirty Checking 구조의 **TOCTOU(Time-of-Check to Time-of-Use)** 문제를 제거하여, 스케줄러와 Redis 리스너가 동시에 실행되더라도 **정확히 한 번만 마감**되도록 개선했습니다.

### 1. 마감 상태 전이를 조건부 UPDATE(CAS)로 변경

- `isClosed()` + Dirty Checking → `closeIfActive(...)` 조건부 UPDATE(`WHERE status = 'ACTIVE'`)로 변경
- `affected rows`를 기반으로 성공 여부를 판단하여 **TOCTOU 제거 및 멱등성 보장**
- 유찰/낙찰 상태를 `CASE WHEN`으로 원자적으로 결정

```sql
CASE
    WHEN highest_bidder_id IS NULL THEN 'NO_BID_CLOSED'
    ELSE 'BID_CLOSED'
END
```

### 2. 승자 정보를 입찰 시점에 선확정

- `raiseCurrentPriceIfHigher(...)`에서 현재가와 함께 `highestBidder`를 원자적으로 갱신
- 마감 시 별도 승자 조회가 필요 없어져 **늦은 입찰(Late Bid) Gap 제거**
- 도메인 명확성을 위해
  - `winner` → `highestBidder`
  - `winner_id` → `highest_bidder_id`

### 3. 입찰 정산 로직 개선 (벌크 UPDATE)

- 정산 순서를 다음과 같이 변경
  1. `markWinningBid()` → 최고가 1건 `WON`
  2. `markLosingBids()` → 나머지 `LOST`
- 정산 로직을 `BidService.settleBids()`로 캡슐화(기존 `closeBids()` 대체)
- `markWinningBid()`의 JPQL 자기참조 서브쿼리가 **MySQL ERROR 1093**을 발생시키는 문제를 확인하여,
  **Native Query (`ORDER BY price DESC, id DESC LIMIT 1`)** 로 변경 후 MySQL 8.0 환경에서 검증

### 4. 트랜잭션 구조 정리

- `closeAuction()`
  - `REQUIRES_NEW`
  - 스케줄러 트랜잭션과 분리
  - 상품(Item) 단위 격리
- `settleBids()`
  - `REQUIRED`
  - 마감 상태 전이 + `WON` + `LOST`를 하나의 트랜잭션으로 원자 커밋
- `AuctionCloseJob`의 불필요한 `@Transactional(readOnly = true)` 제거
  - 루프 수행 중 커넥션이 유휴 상태로 유지되는 문제 개선


### 5. Fail-Open 적용

- `AuctionCloseFacade`에서 **Redis 인프라 장애(`LockInfrastructureException`)** 만 우회
- 락 경합 타임아웃(`LOCK_ACQUISITION_FAILED`)은 기존처럼 **Fast-Fail**
- 최종 정합성은 DB의 **CAS(조건부 UPDATE)** 가 보장하므로 Redis 락 없이도 안전하게 마감 가능

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [x] ♻️ 리팩토링 (refactor)
- [ ] 💄 스타일 (style)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [x] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- ⚠️ **DB 마이그레이션 필요 (배포 전 실행)**

```sql
ALTER TABLE items
RENAME COLUMN winner_id TO highest_bidder_id;
```

- `markWinningBid()`만 예외적으로 **Native Query**를 사용했습니다.
  - JPQL은 `UPDATE`에서 `ORDER BY`, `LIMIT`, 파생 테이블을 지원하지 않아 **MySQL ERROR 1093**을 회피할 수 없었습니다.
  - 실 MySQL 8.0 환경에서 실행 및 동작을 확인했습니다.
  - 나머지 마감 및 정산 쿼리는 모두 **JPQL**을 유지했습니다.

- `highestBidder`는 **마감 전까지 현재 최고 입찰자(선두 입찰자)** 를 의미하는 비정규화 컬럼입니다.
  - 승자 선확정을 위한 의도적인 트레이드오프입니다.
  - `item.highestBidder`와 `bids`는 입찰 시 동일한 UPDATE에서 원자적으로 갱신되어 항상 일관성을 유지합니다.

- 전이 연산의 **version 전파(#101)** 는 이번 PR에 포함하지 않았습니다.
  - 별도의 Fix PR로 진행할 예정입니다.