### PR TITLE
refactor: 쓰기 실패 진단 제거 및 409 Conflict 통일

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionCloseService.java
@@ -26,7 +26,7 @@ public class AuctionCloseService {
             return;
         }
 
-        boolean sold = bidService.settleBids(itemId);
+        boolean sold = bidService.markBidResults(itemId);
         log.info(sold ? "[낙찰] 경매 마감 itemId={}" : "[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -1,7 +1,6 @@
 package io.wisoft.ignoa_api.bid.service;
 
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
-
 import io.wisoft.ignoa_api.bid.dto.response.BidHistory;
 import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
 import io.wisoft.ignoa_api.bid.entity.Bid;
@@ -14,14 +13,12 @@ import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -31,12 +28,10 @@ public class BidService {
 
     private final UserQueryService userQueryService;
     private final ItemReader itemReader;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
-
-    private final ApplicationEventPublisher eventPublisher;
-    private final EntityManager entityManager;
 
     @Transactional
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
@@ -48,22 +43,10 @@ public class BidService {
             throw new BusinessException(ErrorCode.SELF_BID_NOT_ALLOWED);
         }
 
-        if (!item.isActive()) {
-            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
-        }
-
-        if (!item.isValidBidPrice(bidPrice)) {
-            throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
-        }
-
-        if (item.isReachedBuyNowPrice(bidPrice)) {
-            throw new BusinessException(ErrorCode.BID_PRICE_EXCEEDS_BUY_NOW);
-        }
-
-        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, bidder);
+        int updatedRows = itemRepository.raiseCurrentPriceIfHigher(itemId, bidPrice, bidder, LocalDateTime.now());
 
         if (updatedRows == 0) {
-            resolveBidFailure(item);
+            throw new BusinessException(ErrorCode.BID_CONFLICT);
         }
 
         Bid bid = Bid.place(item, bidder, bidPrice);
@@ -74,7 +57,7 @@ public class BidService {
     }
 
     @Transactional
-    public boolean settleBids(Long itemId) {
+    public boolean markBidResults(Long itemId) {
         if (bidRepository.markWinningBid(itemId) == 0) {
             return false;
         }
@@ -91,19 +74,5 @@ public class BidService {
         return bidRepository.findByItemIdWithBidder(itemId).stream()
                 .map(BidHistory::from)
                 .toList();
-    }
-
-    private void resolveBidFailure(Item item) {
-        try {
-            entityManager.refresh(item, LockModeType.PESSIMISTIC_READ);
-        } catch (EntityNotFoundException e) {
-            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
-        }
-
-        if (item.isClosed()) {
-            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
-        }
-
-        throw new BusinessException(ErrorCode.INVALID_BID_PRICE);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "JSON 형식이 올바르지 않습니다."),
     INVALID_PATH_VARIABLE(HttpStatus.BAD_REQUEST, "경로 변수 타입이 올바르지 않습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
-    MISSING_REQUEST_PART(HttpStatus.BAD_REQUEST, "필수 요청 항목이 누락되었습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "다른 요청을 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
@@ -46,21 +45,18 @@ public enum ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     ITEM_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 상품만 수정할 수 있습니다."),
     ITEM_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 상품만 삭제할 수 있습니다."),
-    ITEM_MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 미디어를 찾을 수 없습니다."),
     ITEM_MEDIA_REQUIRED(HttpStatus.BAD_REQUEST, "상품 미디어는 최소 1개 이상이어야 합니다."),
     AUCTION_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 마감된 경매입니다."),
     INVALID_BUY_NOW_PRICE(HttpStatus.BAD_REQUEST, "즉시 구매가는 현재 입찰가보다 낮을 수 없습니다."),
-    INVALID_BUY_NOW_PRICE_ON_CREATE(HttpStatus.BAD_REQUEST, "즉시 구매가는 시작가보다 높아야 합니다."),
     SOLD_ITEM_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "거래가 완료된 상품은 삭제할 수 없습니다."),
     ITEM_WITH_BID_CANNOT_BE_DELETED(HttpStatus.CONFLICT, "입찰 이력이 있는 상품은 삭제할 수 없습니다."),
-    END_AT_TOO_SOON(HttpStatus.BAD_REQUEST, "경매 종료 시간은 최소 1일 이후여야 합니다."),
-    END_AT_TOO_LATE(HttpStatus.BAD_REQUEST, "경매 종료 시간은 최대 7일 이내여야 합니다."),
-    PRICE_CHANGED(HttpStatus.CONFLICT, "즉시구매가가 변경되었습니다. 최신 가격을 확인 후 다시 시도해주세요."),
     ITEM_CONFLICT(HttpStatus.CONFLICT, "수정하는 사이 상품 정보가 변경되었습니다. 최신 정보를 확인 후 다시 시도해주세요."),
+    BUY_NOW_CONFLICT(HttpStatus.CONFLICT, "즉시구매를 처리할 수 없습니다. 최신 경매 상태를 확인 후 다시 시도해주세요."),
+    ITEM_DELETE_CONFLICT(HttpStatus.CONFLICT, "상품을 삭제할 수 없습니다. 진행 중이거나 입찰이 있는 상품은 삭제할 수 없습니다."),
 
     // Bid
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),
-    BID_CONFLICT(HttpStatus.CONFLICT, "현재가가 변경되었습니다. 최신 가격을 확인 후 다시 입찰해주세요."),
+    BID_CONFLICT(HttpStatus.CONFLICT, "입찰이 반영되지 않았습니다. 최신 경매 상태를 확인 후 다시 시도해주세요."),
     SELF_BID_NOT_ALLOWED(HttpStatus.FORBIDDEN, "본인 상품에는 입찰할 수 없습니다."),
     SELF_BUY_NOT_ALLOWED(HttpStatus.FORBIDDEN, "본인 상품은 구매할 수 없습니다."),
     BID_PRICE_EXCEEDS_BUY_NOW(HttpStatus.BAD_REQUEST, "즉시구매가 이상으로 입찰할 수 없습니다. 즉시구매를 이용해주세요."),
@@ -69,7 +65,6 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 파일 크기를 초과했습니다."),
 
     // Wish
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "찜을 찾을 수 없습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
@@ -90,4 +90,11 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
+        log.warn("낙관적 락 충돌: {}", e.getMessage());
+        return ResponseEntity.status(ErrorCode.ITEM_CONFLICT.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.ITEM_CONFLICT));
+    }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -71,8 +71,7 @@ public class Item extends BaseEntity {
     @Version
     private Long version;
 
-    public static Item create(User seller, String title, String description, String category, ItemCondition itemCondition,
-                              String brand, Long startPrice, Long buyNowPrice, LocalDateTime endAt) {
+    public static Item create(User seller, String title, String description, String category,ItemCondition itemCondition, String brand, Long startPrice, Long buyNowPrice, LocalDateTime endAt) {
         return new Item(
                 null, seller, null,
                 title, description, category, itemCondition,
@@ -81,8 +80,7 @@ public class Item extends BaseEntity {
         );
     }
 
-    public void update(String title, String description, String category, String brand,
-                       ItemCondition itemCondition, Long buyNowPrice, LocalDateTime endAt) {
+    public void update(String title, String description, String category, String brand, ItemCondition itemCondition, Long buyNowPrice, LocalDateTime endAt) {
         if (title != null) this.title = title;
         if (description != null) this.description = description;
         if (category != null) this.category = category;
@@ -99,14 +97,6 @@ public class Item extends BaseEntity {
     public boolean isActive() {
         return this.status == ItemStatus.ACTIVE
                 && this.endAt.isAfter(LocalDateTime.now());
-    }
-
-    public boolean isClosed() {
-        return this.status != ItemStatus.ACTIVE;
-    }
-
-    public boolean isValidBidPrice(Long bidPrice) {
-        return this.currentPrice < bidPrice;
     }
 
     public boolean isValidBuyNowPrice(Long buyNowPrice) {

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -3,9 +3,11 @@ package io.wisoft.ignoa_api.item.repository;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
 import io.wisoft.ignoa_api.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -68,18 +70,23 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     boolean existsBySellerIdAndStatus(Long userId, ItemStatus status);
 
+    // 입찰 조건부 UPDATE - 가격(현재가 비교, 즉시구매가 비교), 상태, 마감 시간
     @Modifying
     @Query("""
             UPDATE Item i
-            SET i.currentPrice = :price,
+            SET i.currentPrice = :bidPrice,
                 i.highestBidder = :highestBidder,
                 i.version = i.version + 1
             WHERE i.id = :id
-                AND i.currentPrice < :price
+                AND i.currentPrice < :bidPrice
                 AND i.status = 'ACTIVE'
+                AND i.endAt > :now
+                AND i.buyNowPrice > :bidPrice
             """)
-    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("price") Long price, @Param("highestBidder") User highestBidder);
+    int raiseCurrentPriceIfHigher(@Param("id") Long id, @Param("bidPrice") Long bidPrice,
+                                  @Param("highestBidder") User highestBidder, @Param("now") LocalDateTime now);
 
+    // 즉시구매 조건부 UPDATE - 상태, 마감시간, 즉시구매가 검증
     @Modifying
     @Query("""
             UPDATE Item i
@@ -89,9 +96,12 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             WHERE i.id = :id
                 AND i.status = 'ACTIVE'
                 AND i.buyNowPrice = :buyNowPrice
+                AND i.endAt > :now
             """)
-    int buyNowIfActive(@Param("id") Long id, @Param("buyer") User buyer, @Param("buyNowPrice") Long buyNowPrice);
+    int buyNowIfActive(@Param("id") Long id, @Param("buyer") User buyer,
+                       @Param("buyNowPrice") Long buyNowPrice, @Param("now") LocalDateTime now);
 
+    // 경매 마감 조건부 UPDATE - highestBidder 존재 여부에 따라 상태 변경
     @Modifying
     @Query("""
             UPDATE Item i 
@@ -102,6 +112,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             """)
     int closeIfActive(@Param("id") Long id);
 
+    // 삭제 조건부 UPDATE - 입찰이 없을 때만 가능
     @Modifying
     @Query("""
             UPDATE Item i

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -19,9 +19,6 @@ import io.wisoft.ignoa_api.item.service.dto.UploadedMedia;
 import io.wisoft.ignoa_api.user.entity.User;
 import io.wisoft.ignoa_api.user.service.UserQueryService;
 import io.wisoft.ignoa_api.wish.repository.WishRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -43,7 +41,6 @@ public class ItemCommandService {
 
     private final ItemReader itemReader;
     private final ApplicationEventPublisher eventPublisher;
-    private final EntityManager entityManager;
 
     private final ItemRepository itemRepository;
     private final WishRepository wishRepository;
@@ -74,7 +71,7 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.ITEM_UPDATE_FORBIDDEN);
         }
 
-        if (item.isClosed()) {
+        if (!item.isActive()) {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
@@ -114,7 +111,7 @@ public class ItemCommandService {
         int updatedRows = itemRepository.softDeleteIfActive(itemId);
 
         if (updatedRows == 0) {
-            resolveDeleteFailure(itemId);
+            throw new BusinessException(ErrorCode.ITEM_DELETE_CONFLICT);
         }
 
         wishRepository.deleteAllByItemId(itemId);
@@ -132,41 +129,16 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.SELF_BUY_NOT_ALLOWED);
         }
 
-        if (!item.isActive()) {
-            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
-        }
+        int updatedRows = itemRepository.buyNowIfActive(itemId, user, request.buyNowPrice(), LocalDateTime.now());
 
-        int buyNowRows = itemRepository.buyNowIfActive(itemId, user, request.buyNowPrice());
-
-        if (buyNowRows == 0) {
-            resolveBuyNowFailure(item);
+        if (updatedRows == 0) {
+            throw new BusinessException(ErrorCode.BUY_NOW_CONFLICT);
         }
 
         bidRepository.markLosingBids(itemId);
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
         return new BuyNowResponse(itemId, buyerId, request.buyNowPrice(), ItemStatus.BUY_NOW_CLOSED);
-    }
-
-    private void resolveBuyNowFailure(Item item) {
-        try {
-            entityManager.refresh(item, LockModeType.PESSIMISTIC_READ);
-        } catch (EntityNotFoundException e) {
-            throw new BusinessException(ErrorCode.ITEM_NOT_FOUND);
-        }
-
-        if (item.isClosed()) {
-            throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
-        }
-
-        throw new BusinessException(ErrorCode.PRICE_CHANGED);
-    }
-
-    private void resolveDeleteFailure(Long itemId) {
-        if (bidRepository.existsByItemId(itemId)) {
-            throw new BusinessException(ErrorCode.ITEM_WITH_BID_CANNOT_BE_DELETED);
-        }
-        throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
     }
 
     private List<ItemMedia> toItemMedias(List<UploadedMedia> uploadedMedias, Item item) {

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidServiceConcurrencyTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,49 +43,6 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
         bidRepository.deleteAll();
         itemRepository.deleteAll();
         userRepository.deleteAll();
-    }
-
-    @Test
-    void 같은_상품에_동시_입찰하면_한_건만_성공한다() throws InterruptedException {
-        // Given
-        long bidPrice = 1_100L;
-        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
-        User bidder = userRepository.save(newUser("bidder@test.com", "입찰자"));
-        Item item = itemRepository.save(newItem(seller));
-
-        int threadCount = 10;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-        AtomicInteger successCount = new AtomicInteger();
-        AtomicInteger failCount = new AtomicInteger();
-        
-        // When
-        for (int i = 0; i < threadCount; i++) {
-            executor.submit(() -> {
-                try {
-                    startLatch.await();
-                    bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(bidPrice));
-                    successCount.incrementAndGet();
-                } catch (BusinessException e) {
-                    if (e.getErrorCode() == ErrorCode.INVALID_BID_PRICE) {
-                        failCount.incrementAndGet();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                }
-            });
-        }
-        startLatch.countDown();
-        doneLatch.await(10, TimeUnit.SECONDS);
-        executor.shutdown();
-
-        // Then
-        assertThat(successCount.get()).isEqualTo(1);
-        assertThat(failCount.get()).isEqualTo(threadCount - 1);
-        assertThat(bidRepository.findByItemId(item.getId())).hasSize(1);
     }
 
     @Test
@@ -147,8 +105,8 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
                 () -> bidService.placeBid(item.getId(), bidder.getId(), new BidCreateRequest(1_400L)));
 
         // Then
-        assertThat(samePriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
-        assertThat(lowerPriceException.getErrorCode()).isEqualTo(ErrorCode.INVALID_BID_PRICE);
+        assertThat(samePriceException.getErrorCode()).isEqualTo(ErrorCode.BID_CONFLICT);
+        assertThat(lowerPriceException.getErrorCode()).isEqualTo(ErrorCode.BID_CONFLICT);
     }
 
     @Test
@@ -167,12 +125,11 @@ class BidServiceConcurrencyTest extends IntegrationTestSupport {
 
         // When
         int updatedRows = itemRepository.raiseCurrentPriceIfHigher(
-                item.getId(), bidPrice, bidder);
+                item.getId(), bidPrice, bidder, LocalDateTime.now());
 
         // Then
         assertThat(updatedRows).isZero();
         Item reloaded = itemRepository.findById(item.getId()).orElseThrow();
         assertThat(reloaded.getCurrentPrice()).isEqualTo(before);
     }
-
 }

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemBuyNowTest.java
@@ -1,7 +1,5 @@
 package io.wisoft.ignoa_api.item.service;
 
-import io.wisoft.ignoa_api.global.exception.BusinessException;
-import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.response.BuyNowResponse;
 import io.wisoft.ignoa_api.item.entity.Item;
@@ -13,13 +11,6 @@ import io.wisoft.ignoa_api.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,53 +47,5 @@ class ItemBuyNowTest extends IntegrationTestSupport {
 
         Item reloaded = itemRepository.findById(item.getId()).orElseThrow();
         assertThat(reloaded.getStatus()).isEqualTo(ItemStatus.BUY_NOW_CLOSED);
-    }
-
-    @Test
-    void 동시에_즉시구매하면_한_건만_성공하고_나머지는_실패한다() throws InterruptedException {
-        // Given
-        User seller = userRepository.save(newUser("seller@test.com", "seller"));
-        Item item = itemRepository.save(newItem(seller));
-        ItemBuyNowRequest request = new ItemBuyNowRequest(item.getBuyNowPrice());
-
-        int threadCount = 10;
-
-        List<Long> buyerIds = new ArrayList<>();
-        for (int i = 0; i < threadCount; i++) {
-            buyerIds.add(userRepository.save(
-                    newUser("buyer" + i + "@test.com", "buyer" + i)).getId());
-        }
-
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-        AtomicInteger successCount = new AtomicInteger();
-        AtomicInteger failCount = new AtomicInteger();
-
-        // When
-        for (Long buyerId : buyerIds) {
-            executor.submit(() -> {
-                try {
-                    startLatch.await();
-                    itemCommandService.buyNowItem(item.getId(), buyerId, request);
-                    successCount.incrementAndGet();
-                } catch (BusinessException e) {
-                    if (e.getErrorCode() == ErrorCode.AUCTION_ALREADY_CLOSED) {
-                        failCount.incrementAndGet();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                }
-            });
-        }
-        startLatch.countDown();
-        doneLatch.await();
-        executor.shutdown();
-
-        // Then
-        assertThat(successCount.get()).isOne();
-        assertThat(failCount.get()).isEqualTo(threadCount - 1);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #110 

---

## 📝 작업 내용 (Description)

> 조건부 UPDATE 0행 처리에서 실패 원인을 재조회로 진단하던 로직을 제거하고 409 conflict로 통일했습니다.
> 재조회가 stale 엔티티에 락을 걸며 낙관적 락 충돌(→500)을 유발했고, 세 경우 모두 사용자 행동이 "최신 상태 확인 후 재시도"로 동일해 세분화 > 실익이 낮았습니다. 정합성은 조건부 UPDATE의 WHERE가 그대로 보장합니다.

### 1. 진단 제거 → 409 통일
- 입찰·즉시구매·삭제 0행 시 `BID_CONFLICT` · `BUY_NOW_CONFLICT` · `ITEM_DELETE_CONFLICT` 반환

### 2. 낙관적 락 충돌 방어 + 정리
- `GlobalExceptionHandler`에 핸들러 추가 → `ITEM_CONFLICT`(409)
- `getByIdForShare` 등 진단용 조회·미사용 ErrorCode·import 제거

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [ ] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- 순수 리팩터링이 아니라 **에러 응답이 의도적으로 변경**됩니다.
- (`INVALID_BID_PRICE`→`BID_CONFLICT` 등, 낙관적 락 충돌 500→409)
- 정합성(1건만 성공·Lost Update 없음)은 기존과 동일하게 유지됩니다.