### PR TITLE
feat: 첫 입찰 이후 즉시구매가 변경 제한

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     BUY_NOW_CONFLICT(HttpStatus.CONFLICT, "즉시구매를 처리할 수 없습니다. 최신 경매 상태를 확인 후 다시 시도해주세요."),
     ITEM_DELETE_CONFLICT(HttpStatus.CONFLICT, "상품을 삭제할 수 없습니다. 진행 중이거나 입찰이 있는 상품은 삭제할 수 없습니다."),
     AUCTION_EXTEND_CONFLICT(HttpStatus.CONFLICT, "경매를 연장할 수 없습니다. 마감 상태와 연장 가능 횟수를 확인해주세요."),
+    BUY_NOW_PRICE_CHANGED_NOT_ALLOWED(HttpStatus.CONFLICT, "첫 입찰 이후에는 즉시구매가를 변경할 수 없습니다."),
 
     // Bid
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "입찰 금액은 현재 최고가보다 높아야 합니다."),
@@ -75,4 +76,3 @@ public enum ErrorCode {
     private final HttpStatus httpStatus;
     private final String message;
 }
-

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/Item.java
@@ -103,10 +103,12 @@ public class Item extends BaseEntity {
     }
 
     public boolean isValidBuyNowPrice(Long buyNowPrice) {
-        return buyNowPrice == null || buyNowPrice > this.currentPrice;
+        return buyNowPrice == null
+                || buyNowPrice > this.currentPrice;
     }
 
-    public boolean isReachedBuyNowPrice(Long bidPrice) {
-        return bidPrice >= this.buyNowPrice;
+    public boolean isBuyNowPriceChanged(Long buyNowPrice) {
+        return buyNowPrice != null
+                && !buyNowPrice.equals(this.buyNowPrice);
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -75,9 +75,7 @@ public class ItemCommandService {
             throw new BusinessException(ErrorCode.AUCTION_ALREADY_CLOSED);
         }
 
-        if (!item.isValidBuyNowPrice(request.buyNowPrice())) {
-            throw new BusinessException(ErrorCode.INVALID_BUY_NOW_PRICE);
-        }
+        validateBuyNowPrice(item, itemId, request.buyNowPrice());
 
         item.update(request.title(), request.description(), request.category(),
                 request.brand(), request.itemCondition(), request.buyNowPrice()
@@ -133,6 +131,19 @@ public class ItemCommandService {
         eventPublisher.publishEvent(new AuctionClosedEvent(itemId));
 
         return new BuyNowResponse(itemId, buyerId, request.buyNowPrice(), ItemStatus.BUY_NOW_CLOSED);
+    }
+
+    private void validateBuyNowPrice(Item item, Long itemId, Long buyNowPrice) {
+        // 즉시구매가 변경 시, 입찰 이력이 있으면 변경 불가
+        if (item.isBuyNowPriceChanged(buyNowPrice)
+                && bidRepository.existsByItemId(itemId)) {
+            throw new BusinessException(ErrorCode.BUY_NOW_PRICE_CHANGED_NOT_ALLOWED);
+        }
+
+        // 즉시구매가는 현재 입찰가보다 높아야 함
+        if (!item.isValidBuyNowPrice(buyNowPrice)) {
+            throw new BusinessException(ErrorCode.INVALID_BUY_NOW_PRICE);
+        }
     }
 
     private List<ItemMedia> toItemMedias(List<UploadedMedia> uploadedMedias, Item item) {


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #114
- related: #

---

## 📝 작업 내용 (Description)

첫 입찰 이후 즉시구매가 변경을 제한해 입찰 참여자의 가격 판단 기준이 변경되지 않도록 처리했습니다.

### 1. 즉시구매가 변경 여부 분리
- 요청 즉시구매가가 `null`이 아니고 기존 값과 다른 경우만 실제 변경으로 판단합니다.
- 동일 즉시구매가 요청과 즉시구매가 외 상품 정보 수정은 입찰 이력과 무관하게 허용합니다.

### 2. 첫 입찰 이후 변경 제한
- 실제 가격 변경 요청에 입찰 이력이 있으면 `BUY_NOW_PRICE_CHANGED_NOT_ALLOWED`(409 Conflict)를 반환합니다.
- 변경 가능한 경우에도 기존처럼 즉시구매가가 현재 입찰가보다 높은지 검증합니다.

### 3. 경합 정합성
- 입찰·마감·즉시구매 시 `Item` version 증가 정책을 통해 수정과 입찰 사이의 경합은 낙관적 락 충돌로 롤백됩니다.

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [ ] build & 테스트가 통과합니다
- [ ] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- 동일 즉시구매가 요청은 가격 변경으로 판단하지 않아 200으로 처리됩니다.
- 테스트는 이번 작업에서 실행하지 않았습니다.