### PR TITLE
feat: 락 대기·점유·트랜잭션·커넥션 구간별 시간 계측 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// 개발 편의
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionFacade.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.auction.service;
 
 import io.wisoft.ignoa_api.auction.dto.response.AuctionExtensionResponse;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class AuctionFacade {
     public void closeAuction(Long itemId) {
         distributedLock.executeWithLockOrFailOpen(
                 ItemLockKey.of(itemId),
+                LockOperation.AUTO_CLOSE,
                 CLOSE_WAIT_MILLIS,
                 () -> auctionService.closeAuction(itemId)
         );
@@ -29,9 +31,9 @@ public class AuctionFacade {
     public AuctionExtensionResponse extendAuction(Long itemId, Long userId) {
         return distributedLock.executeWithLockOrFailOpen(
                 ItemLockKey.of(itemId),
+                LockOperation.EXTEND,
                 EXTEND_WAIT_MILLIS,
                 () -> auctionService.extendAuction(itemId, userId)
         );
     }
 }
-

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
@@ -5,6 +5,8 @@ import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
 import io.wisoft.ignoa_api.bid.service.BidService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
+import io.wisoft.ignoa_api.global.infra.metrics.MeasureTransaction;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemReader;
@@ -28,6 +30,7 @@ public class AuctionService {
     private final ItemRepository itemRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    @MeasureTransaction(operation = LockOperation.AUTO_CLOSE)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void closeAuction(Long itemId) {
         int updatedRows = itemRepository.closeIfActive(itemId, LocalDateTime.now());
@@ -42,6 +45,7 @@ public class AuctionService {
                 : "[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
     }
 
+    @MeasureTransaction(operation = LockOperation.EXTEND)
     @Transactional
     public AuctionExtensionResponse extendAuction(Long itemId, Long sellerId) {
         Item item = itemReader.getByIdWithSeller(itemId);

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidFacade.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.bid.service;
 
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
 import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +22,9 @@ public class BidFacade {
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
         return distributedLock.executeWithLockOrFailOpen(
                 ItemLockKey.of(itemId),
+                LockOperation.BID,
                 BID_WAIT_MILLIS,
                 () -> bidService.placeBid(itemId, bidderId, request)
         );
     }
 }
-

--- a/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
+++ b/src/main/java/io/wisoft/ignoa_api/bid/service/BidService.java
@@ -5,6 +5,8 @@ import io.wisoft.ignoa_api.bid.dto.response.BidHistory;
 import io.wisoft.ignoa_api.bid.dto.response.BidResponse;
 import io.wisoft.ignoa_api.bid.entity.Bid;
 import io.wisoft.ignoa_api.bid.event.BidPlaceEvent;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
+import io.wisoft.ignoa_api.global.infra.metrics.MeasureTransaction;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
@@ -33,6 +35,7 @@ public class BidService {
     private final BidRepository bidRepository;
     private final ItemRepository itemRepository;
 
+    @MeasureTransaction(operation = LockOperation.BID)
     @Transactional
     public BidResponse placeBid(Long itemId, Long bidderId, BidCreateRequest request) {
         Long bidPrice = request.price();

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockAcquireOutcome.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockAcquireOutcome.java
@@ -1,0 +1,20 @@
+package io.wisoft.ignoa_api.global.infra.lock;
+
+public enum LockAcquireOutcome {
+
+    ACQUIRED("acquired"),
+    TIMEOUT("timeout"),
+    INTERRUPTED("interrupted"),
+    INFRA_ERROR("infra_error"),
+    ERROR("error");
+
+    private final String metricTag;
+
+    LockAcquireOutcome(String metricTag) {
+        this.metricTag = metricTag;
+    }
+
+    public String metricTag() {
+        return metricTag;
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockOperation.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/LockOperation.java
@@ -1,0 +1,24 @@
+package io.wisoft.ignoa_api.global.infra.lock;
+
+public enum LockOperation {
+
+    BID("bid"),
+    BUY_NOW("buy_now"),
+    EXTEND("extend"),
+    UPDATE("update"),
+    DELETE("delete"),
+    AUTO_CLOSE("auto_close");
+
+    private final String metricTag;
+
+    LockOperation(String metricTag) {
+        this.metricTag = metricTag;
+    }
+
+    public String metricTag() {
+        return metricTag;
+    }
+}
+
+
+

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
@@ -24,25 +24,25 @@ public class RedissonDistributedLock {
     private final RedissonClient redissonClient;
     private final MeterRegistry meterRegistry;
 
-    public <T> T executeWithLockOrFailOpen(String key, long waitMillis, Supplier<T> task) {
+    public <T> T executeWithLockOrFailOpen(String key, LockOperation operation, long waitMillis, Supplier<T> task) {
         try {
-            return execute(key, waitMillis, task);
+            return execute(key, operation, waitMillis, task);
         } catch (LockInfrastructureException e) {
             log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}", key, e);
             return task.get();
         }
     }
 
-    public void executeWithLockOrFailOpen(String key, long waitMillis, Runnable task) {
+    public void executeWithLockOrFailOpen(String key, LockOperation operation, long waitMillis, Runnable task) {
         try {
-            execute(key, waitMillis, toSupplier(task));
+            execute(key, operation, waitMillis, toSupplier(task));
         } catch (LockInfrastructureException e) {
             log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}", key, e);
             task.run();
         }
     }
 
-    private <T> T execute(String key, long waitMillis, Supplier<T> task) {
+    private <T> T execute(String key, LockOperation operation, long waitMillis, Supplier<T> task) {
         RLock lock = redissonClient.getLock(key);
         boolean acquired;
 
@@ -62,6 +62,7 @@ public class RedissonDistributedLock {
         try {
             Timer holdTimer = Timer.builder("lock.hold.time")
                     .tag("key", keyPrefix(key))
+                    .tag("operation", operation.metricTag())
                     .publishPercentiles(0.5, 0.95, 0.99)
                     .register(meterRegistry);
 

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
@@ -98,7 +98,6 @@ public class RedissonDistributedLock {
                 .tags("key", keyPrefix(key))
                 .tag("operation", operation.metricTag())
                 .tags("outcome", outcome.metricTag())
-                .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry);
 
         sample.stop(acquireWaitTimer);
@@ -109,7 +108,6 @@ public class RedissonDistributedLock {
         Timer holdTimer = Timer.builder("lock.hold.time")
                 .tag("key", keyPrefix(key))
                 .tag("operation", operation.metricTag())
-                .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry);
 
         return holdTimer.record(task);

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLock.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.global.infra.lock;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class RedissonDistributedLock {
         try {
             return execute(key, operation, waitMillis, task);
         } catch (LockInfrastructureException e) {
-            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}", key, e);
+            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}, operation={}", key, operation, e);
             return task.get();
         }
     }
@@ -37,41 +38,81 @@ public class RedissonDistributedLock {
         try {
             execute(key, operation, waitMillis, toSupplier(task));
         } catch (LockInfrastructureException e) {
-            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}", key, e);
+            log.warn("Redis 인프라 장애로 fail-open 처리 - 락 없이 진행. key={}, operation={}", key, operation, e);
             task.run();
         }
     }
 
+    // 실제 락 획득 로직, Task를 실행하고 락을 해제한다.
     private <T> T execute(String key, LockOperation operation, long waitMillis, Supplier<T> task) {
         RLock lock = redissonClient.getLock(key);
-        boolean acquired;
 
-        try {
-            acquired = lock.tryLock(waitMillis, LEASE_TIME_MILLIS, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
-        } catch (RedisException e) {
-            throw new LockInfrastructureException("Redis 인프라 장애 - 분산 락 획득 실패, key = " + key, e);
-        }
+        boolean acquired = acquireLock(lock, key, operation, waitMillis);
 
         if (!acquired) {
             throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
         }
 
         try {
-            Timer holdTimer = Timer.builder("lock.hold.time")
-                    .tag("key", keyPrefix(key))
-                    .tag("operation", operation.metricTag())
-                    .publishPercentiles(0.5, 0.95, 0.99)
-                    .register(meterRegistry);
-
-            return holdTimer.record(task);
+            return recordHoldTime(key, operation, task);
         } finally {
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
         }
+    }
+
+    private boolean acquireLock(RLock lock, String key, LockOperation operation, long waitMillis) {
+        Sample sample = Timer.start(meterRegistry);
+        LockAcquireOutcome outcome = LockAcquireOutcome.ERROR;
+
+        try {
+            boolean acquired = lock.tryLock(
+                    waitMillis,
+                    LEASE_TIME_MILLIS,
+                    TimeUnit.MILLISECONDS
+            );
+
+            outcome = acquired
+                    ? LockAcquireOutcome.ACQUIRED
+                    : LockAcquireOutcome.TIMEOUT;
+
+            return acquired;
+
+        } catch (InterruptedException e) {
+            outcome = LockAcquireOutcome.INTERRUPTED;
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED);
+
+        } catch (RedisException e) {
+            outcome = LockAcquireOutcome.INFRA_ERROR;
+            throw new LockInfrastructureException("Redis 인프라 장애 - 분산 락 획득 실패, key = " + key, e);
+
+        } finally {
+            recordAcquireWaitTime(sample, key, operation, outcome);
+        }
+    }
+
+    private void recordAcquireWaitTime(Sample sample, String key, LockOperation operation, LockAcquireOutcome outcome) {
+        Timer acquireWaitTimer = Timer.builder("lock.acquire.wait")
+                .tags("key", keyPrefix(key))
+                .tag("operation", operation.metricTag())
+                .tags("outcome", outcome.metricTag())
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+
+        sample.stop(acquireWaitTimer);
+    }
+
+
+    private <T> T recordHoldTime(String key, LockOperation operation, Supplier<T> task) {
+        Timer holdTimer = Timer.builder("lock.hold.time")
+                .tag("key", keyPrefix(key))
+                .tag("operation", operation.metricTag())
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+
+        return holdTimer.record(task);
     }
 
     private static Supplier<Object> toSupplier(Runnable task) {

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/metrics/MeasureTransaction.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/metrics/MeasureTransaction.java
@@ -1,0 +1,15 @@
+package io.wisoft.ignoa_api.global.infra.metrics;
+
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MeasureTransaction {
+
+    LockOperation operation();
+}

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/metrics/MeasureTransactionAspect.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/metrics/MeasureTransactionAspect.java
@@ -1,0 +1,36 @@
+package io.wisoft.ignoa_api.global.infra.metrics;
+
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RequiredArgsConstructor
+public class MeasureTransactionAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Around(value = "@annotation(measureTransaction)")
+    public Object measure(ProceedingJoinPoint joinPoint, MeasureTransaction measureTransaction) throws Throwable {
+        Timer timer = Timer.builder("transaction.duration")
+                .tag("operation", measureTransaction.operation().metricTag())
+                .register(meterRegistry);
+
+        Timer.Sample sample = Timer.start(meterRegistry);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            sample.stop(timer);
+        }
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemCommandService.java
@@ -5,6 +5,8 @@ import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
 import io.wisoft.ignoa_api.bid.repository.BidRepository;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
+import io.wisoft.ignoa_api.global.infra.metrics.MeasureTransaction;
 import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemCreateRequest;
 import io.wisoft.ignoa_api.item.dto.request.ItemUpdateRequest;
@@ -64,6 +66,7 @@ public class ItemCommandService {
         return new ItemIdResponse(item.getId());
     }
 
+    @MeasureTransaction(operation = LockOperation.UPDATE)
     public ItemDetail updateItem(Long itemId, Long userId, ItemUpdateRequest request, List<UploadedMedia> uploadedMedias) {
         Item item = itemReader.getByIdWithSeller(itemId);
 
@@ -93,6 +96,7 @@ public class ItemCommandService {
         return itemQueryService.getItem(itemId, userId);
     }
 
+    @MeasureTransaction(operation = LockOperation.DELETE)
     public ItemIdResponse deleteItem(Long itemId, Long userId) {
         Item item = itemReader.getByIdWithSeller(itemId);
 
@@ -113,6 +117,7 @@ public class ItemCommandService {
         return new ItemIdResponse(itemId);
     }
 
+    @MeasureTransaction(operation = LockOperation.BUY_NOW)
     public BuyNowResponse buyNowItem(Long itemId, Long buyerId, ItemBuyNowRequest request) {
         Item item = itemReader.getById(itemId);
         User user = userQueryService.findById(buyerId);

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
@@ -58,6 +59,7 @@ public class ItemFacade {
 
             return distributedLock.executeWithLockOrFailOpen(
                     ItemLockKey.of(itemId),
+                    LockOperation.UPDATE,
                     MODIFY_WAIT_MILLIS,
                     () -> itemCommandService.updateItem(itemId, userId, request, uploadedMedias)
             );
@@ -74,6 +76,7 @@ public class ItemFacade {
     public ItemIdResponse deleteItem(Long itemId, Long userId) {
         return distributedLock.executeWithLockOrFailOpen(
                 ItemLockKey.of(itemId),
+                LockOperation.DELETE,
                 MODIFY_WAIT_MILLIS,
                 () -> itemCommandService.deleteItem(itemId, userId));
     }
@@ -81,6 +84,7 @@ public class ItemFacade {
     public BuyNowResponse buyNowItem(Long itemId, Long buyerId, ItemBuyNowRequest request) {
         return distributedLock.executeWithLockOrFailOpen(
                 ItemLockKey.of(itemId),
+                LockOperation.BUY_NOW,
                 BUY_NOW_WAIT_MILLIS,
                 () -> itemCommandService.buyNowItem(itemId, buyerId, request));
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -4,6 +4,9 @@ spring:
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      connection-timeout: 500
 
   jpa:
     hibernate:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -36,3 +36,4 @@ management:
         http.server.requests: true
         lock.hold.time: true
         lock.acquire.wait: true
+        hikaricp.connections.acquire: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -9,6 +9,9 @@ spring:
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      connection-timeout: 500ms
 
   jpa:
     hibernate:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,7 +11,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 10
-      connection-timeout: 500ms
+      connection-timeout: 500
 
   jpa:
     hibernate:
@@ -35,3 +35,4 @@ management:
       percentiles-histogram:
         http.server.requests: true
         lock.hold.time: true
+        lock.acquire.wait: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,3 +37,4 @@ management:
         lock.hold.time: true
         lock.acquire.wait: true
         hikaricp.connections.acquire: true
+        transaction.duration: true

--- a/src/test/java/io/wisoft/ignoa_api/bid/service/BidFacadeTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/bid/service/BidFacadeTest.java
@@ -3,6 +3,7 @@ package io.wisoft.ignoa_api.bid.service;
 import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,8 @@ class BidFacadeTest {
         Long bidderId = 2L;
         BidCreateRequest request = new BidCreateRequest(1_000L);
 
-        given(distributedLock.executeWithLockOrFailOpen(eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
+        given(distributedLock.executeWithLockOrFailOpen(
+                eq(ItemLockKey.of(itemId)), eq(LockOperation.BID), anyLong(), any(Supplier.class)))
                 .willThrow(new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED));
 
         // When

--- a/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
@@ -1,6 +1,7 @@
 package io.wisoft.ignoa_api.global.infra.lock;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,10 +34,12 @@ class RedissonDistributedLockTest {
     RLock lock;
 
     RedissonDistributedLock distributedLock;
+    SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
-        distributedLock = new RedissonDistributedLock(redissonClient, new SimpleMeterRegistry());
+        meterRegistry = new SimpleMeterRegistry();
+        distributedLock = new RedissonDistributedLock(redissonClient, meterRegistry);
         given(redissonClient.getLock(anyString())).willReturn(lock);
     }
 
@@ -52,7 +55,7 @@ class RedissonDistributedLockTest {
         // When
         BusinessException exception = catchThrowableOfType(
                 BusinessException.class,
-                () -> distributedLock.executeWithLockOrFailOpen(key, waitTime, () -> "결과")
+                () -> distributedLock.executeWithLockOrFailOpen(key, LockOperation.BID, waitTime, () -> "결과")
         );
 
         // Then
@@ -70,7 +73,7 @@ class RedissonDistributedLockTest {
                 .willThrow(new RedisException("Redis 장애"));
 
         // When
-        String result = distributedLock.executeWithLockOrFailOpen(key, waitTime, () -> "결과");
+        String result = distributedLock.executeWithLockOrFailOpen(key, LockOperation.BID, waitTime, () -> "결과");
 
         // Then
         assertThat(result).isEqualTo("결과");
@@ -87,10 +90,16 @@ class RedissonDistributedLockTest {
         given(lock.isHeldByCurrentThread()).willReturn(true);
 
         // When
-        String result = distributedLock.executeWithLockOrFailOpen(key, waitTime, () -> "입찰 완료");
+        String result = distributedLock.executeWithLockOrFailOpen(key, LockOperation.BID, waitTime, () -> "입찰 완료");
 
         // Then
         assertThat(result).isEqualTo("입찰 완료");
         verify(lock).unlock();
+
+        Timer holdTimer = meterRegistry.find("lock.hold.time")
+                .tags("key", "item:lock", "operation", "bid")
+                .timer();
+        assertThat(holdTimer).isNotNull();
+        assertThat(holdTimer.count()).isEqualTo(1);
     }
 }

--- a/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/global/infra/lock/RedissonDistributedLockTest.java
@@ -101,5 +101,15 @@ class RedissonDistributedLockTest {
                 .timer();
         assertThat(holdTimer).isNotNull();
         assertThat(holdTimer.count()).isEqualTo(1);
+
+        Timer acquireWaitTimer = meterRegistry.find("lock.acquire.wait")
+                .tags(
+                        "key", "item:lock",
+                        "operation", "bid",
+                        "outcome", "acquired"
+                )
+                .timer();
+        assertThat(acquireWaitTimer).isNotNull();
+        assertThat(acquireWaitTimer.count()).isEqualTo(1);
     }
 }

--- a/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/item/service/ItemFacadeTest.java
@@ -2,6 +2,7 @@ package io.wisoft.ignoa_api.item.service;
 
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
+import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
 import io.wisoft.ignoa_api.item.support.ItemLockKey;
@@ -41,7 +42,7 @@ class ItemFacadeTest {
         ItemBuyNowRequest request = new ItemBuyNowRequest(10_000L);
 
         given(redissonDistributedLock.executeWithLockOrFailOpen(
-                eq(ItemLockKey.of(itemId)), anyLong(), any(Supplier.class)))
+                eq(ItemLockKey.of(itemId)), eq(LockOperation.BUY_NOW), anyLong(), any(Supplier.class)))
                 .willThrow(new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED));
 
         // When


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #116 

---

## 📝 작업 내용 (Description)

  ### 1. 락 대기·점유 시간 계측

  - `lock.acquire.wait` Timer 추가
  - outcome 태그 분리: `acquired`, `timeout`, `interrupted`, `infra_error`, `error`
  - 기존 `lock.hold.time`과 함께 조회해 락 대기 시간과 락 획득 후 작업 시간을 분리 관측

  ### 2. 락 메트릭 작업 유형 태그 적용

  - `LockOperation` 도입: `bid`, `buy_now`, `extend`, `update`, `delete`, `auto_close`
  - `executeWithLockOrFailOpen()` 호출 시 operation을 전달해 락 지표를 작업별로 필터링

  ### 3. 작업별 트랜잭션 시간 계측

  - `@MeasureTransaction(operation = ...)` 애너테이션과 AOP 추가
  - `transaction.duration`에 operation별 트랜잭션 시간 기록
  - 트랜잭션 시작, DB 커넥션 획득, 비즈니스 로직, commit/rollback까지 포함해 측정
  - `spring-boot-starter-aop` 의존성 추가

  ### 4. HikariCP 커넥션 획득 시간 histogram 활성화

  - `hikaricp.connections.acquire` histogram 활성화
  - 풀 전체 커넥션 획득 지연을 `lock.hold.time`, `transaction.duration`과 같은 시간축에서 비교

  ### 5. Prometheus histogram 기반 백분위수 조회

  - 앱 내부 `publishPercentiles` 대신 Prometheus histogram bucket 사용
  - 대상: `http.server.requests`, `lock.acquire.wait`, `lock.hold.time`, `transaction.duration`, `hikaricp.connections.acquire`



---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] build & 테스트가 통과합니다
- [ ] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

  - `/actuator/prometheus`에서 락 획득 대기·락 보유·트랜잭션·Hikari 획득 histogram 노출을 확인했습니다.
  - Grafana 시간 예산 대시보드는 `ignoa-monitoring` 레포에서 별도 반영했습니다.
  - k6 결과를 바탕으로 waitTime, leaseTime, Hikari `connection-timeout`, transaction timeout 값은 후속 작업에서 결정합니다.
