### PR TITLE
feat: 경매 낙찰 시 채팅방 자동 생성

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
@@ -3,9 +3,9 @@ package io.wisoft.ignoa_api.auction.service;
 import io.wisoft.ignoa_api.auction.dto.response.AuctionExtensionResponse;
 import io.wisoft.ignoa_api.auction.event.AuctionRegisteredEvent;
 import io.wisoft.ignoa_api.bid.service.BidService;
+import io.wisoft.ignoa_api.chat.service.ChatRoomService;
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
-import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import io.wisoft.ignoa_api.item.service.ItemReader;
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 public class AuctionService {
 
     private final BidService bidService;
+    private final ChatRoomService chatRoomService;
     private final ItemReader itemReader;
     private final ItemRepository itemRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -38,9 +39,15 @@ public class AuctionService {
             return;
         }
 
-        boolean result = bidService.markBidResults(itemId);
-        log.info(result ? "[낙찰] 경매 마감 itemId={}"
-                : "[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
+        boolean hasWinner = bidService.markBidResults(itemId);
+
+        if (!hasWinner) {
+            log.info("[유찰] 입찰 없이 마감된 경매 itemId={}", itemId);
+            return;
+        }
+
+        chatRoomService.createChat(itemId);
+        log.info("[낙찰] 경매 마감 및 채팅방 생성 itemId={}", itemId);
     }
 
     @Transactional

--- a/src/main/java/io/wisoft/ignoa_api/chat/entity/ChatRoom.java
+++ b/src/main/java/io/wisoft/ignoa_api/chat/entity/ChatRoom.java
@@ -1,0 +1,52 @@
+package io.wisoft.ignoa_api.chat.entity;
+
+import io.wisoft.ignoa_api.global.common.BaseEntity;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        name = "chat_rooms",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_chat_rooms_item_buyer",
+                columnNames = {"item_id", "buyer_id"}
+        )
+)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", nullable = false)
+    private User seller;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "buyer_id", nullable = false)
+    private User buyer;
+
+    public static ChatRoom create(Item item, User seller, User buyer) {
+        return new ChatRoom(null, item, seller, buyer);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package io.wisoft.ignoa_api.chat.repository;
+
+import io.wisoft.ignoa_api.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    boolean existsByItemIdAndBuyerId(Long itemId, Long buyerId);
+}

--- a/src/main/java/io/wisoft/ignoa_api/chat/service/ChatRoomService.java
+++ b/src/main/java/io/wisoft/ignoa_api/chat/service/ChatRoomService.java
@@ -1,0 +1,35 @@
+package io.wisoft.ignoa_api.chat.service;
+
+import io.wisoft.ignoa_api.chat.entity.ChatRoom;
+import io.wisoft.ignoa_api.chat.repository.ChatRoomRepository;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.service.ItemReader;
+import io.wisoft.ignoa_api.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ItemReader itemReader;
+
+    @Transactional
+    public void createChat(Long itemId) {
+        Item item = itemReader.getById(itemId);
+        User buyer = item.getHighestBidder();
+
+        if (buyer == null) {
+            return;
+        }
+
+        if (chatRoomRepository.existsByItemIdAndBuyerId(item.getId(), buyer.getId())) {
+            return;
+        }
+
+        ChatRoom chatRoom = ChatRoom.create(item, item.getSeller(), buyer);
+        chatRoomRepository.save(chatRoom);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/entity/User.java
@@ -11,7 +11,10 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         name = "users",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "oauth_id"})
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_users_provider_oauth_id",
+                columnNames = {"provider", "oauth_id"}
+        )
 )
 public class User extends BaseEntity {
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- resolves: #130

---

## 📝 작업 내용 (Description)

경매가 낙찰되면 판매자와 낙찰자가 거래를 진행할 수 있도록 마감 처리 과정에서 채팅방을 자동 생성합니다.

### 1. 채팅방 도메인 구성

- `ChatRoom` 엔티티와 Repository 추가
- 상품·판매자·구매자 관계 구성
- `UNIQUE(item_id, buyer_id)` 제약으로 중복 채팅방 방지

### 2. 낙찰 마감과 채팅방 생성 연결

- 조건부 마감 UPDATE가 성공한 요청만 후속 처리
- 입찰 결과 확정 후 낙찰된 경우에만 채팅방 생성
- 유찰 및 중복 마감 요청에서는 채팅방을 생성하지 않도록 처리
- 마감 상태 변경·입찰 결과 반영·채팅방 생성을 하나의 트랜잭션으로 처리

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [ ] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [ ] build & 테스트가 통과합니다
- [ ] 필요한 경우 테스트 / 문서를 추가·수정했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- `compileJava`와 `git diff --check`를 통과했습니다.
- 메시지 송수신과 채팅방 조회 API는 이번 작업 범위에서 제외했습니다.
- 낙찰·유찰·중복 마감 시나리오 검증 후 Ready for review로 전환할 예정입니다.
