### PR TITLE
fix: Origin 검증 실패 응답을 403으로 유지

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/security/CloudFrontOriginFilter.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/security/CloudFrontOriginFilter.java
@@ -50,7 +50,7 @@ public class CloudFrontOriginFilter extends OncePerRequestFilter {
                 || !MessageDigest.isEqual(
                 secret, requestSecret.getBytes(StandardCharsets.UTF_8)
         )) {
-            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- related: #132

---

## 📝 작업 내용 (Description)

Origin Header 검증 실패 시 `sendError(403)`의 오류 디스패치로 최종 응답이 `401`로 변경되는 문제를 수정했습니다.

- `sendError(403)`을 `setStatus(403)`으로 변경
- Header 누락·불일치 요청이 `403 Forbidden`을 유지하도록 처리

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 셀프 리뷰를 진행했습니다
- [ ] EC2 재배포 후 직접 요청이 `403 Forbidden`으로 반환되는지 확인합니다
