### PR TITLE
chore: 사용자 지정 도메인 적용

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
                 "http://localhost:35173",
-                "https://ignoa.wisoft.dev",
+                "https://ignoa.woomin.dev",
                 "https://dudk7ec6su821.cloudfront.net"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- closes: #135

---

## 📝 작업 내용 (Description)

CloudFront 사용자 지정 도메인에서 API 요청이 정상적으로 처리되도록 CORS 허용 Origin을 변경했습니다.

- 기존 `https://ignoa.wisoft.dev` 제거
- 신규 `https://ignoa.woomin.dev` 추가
- 로컬 개발 환경과 CloudFront 기본 도메인 허용 설정 유지

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [x] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 셀프 리뷰를 진행했습니다
- [ ] EC2 재배포 후 사용자 지정 도메인에서 API 요청을 확인합니다
- [ ] 카카오 로그인과 Refresh Token Cookie 동작을 확인합니다
