### PR TITLE
feat: CloudFront 기반 미디어 이미지 제공

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/global/infra/storage/MediaUrlResolver.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/storage/MediaUrlResolver.java
@@ -1,19 +1,14 @@
 package io.wisoft.ignoa_api.global.infra.storage;
 
 import io.wisoft.ignoa_api.user.entity.ProfileImageSource;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import software.amazon.awssdk.services.s3.S3Client;
 
 @Component
-@RequiredArgsConstructor
 public class MediaUrlResolver {
 
-    private final S3Client s3Client;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    @Value("${cloud.aws.cloudfront.media-base-url}")
+    private String mediaBaseUrl;
 
     // 외부 URL(카카오)과 S3 Object Key가 함께 저장될 수 있는 프로필 이미지에 사용
     public String toUrl(String reference, ProfileImageSource source) {
@@ -25,11 +20,7 @@ public class MediaUrlResolver {
             return reference;
         }
 
-        return s3Client.utilities()
-                .getUrl(builder -> builder
-                        .bucket(bucket)
-                        .key(reference))
-                .toExternalForm();
+        return "%s/%s".formatted(mediaBaseUrl, reference);
     }
 
     // 항상 S3 Object Key를 저장하는 상품 이미지에 사용

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,9 @@ cloud:
     s3:
       bucket: ${S3_BUCKET}
       region: ${S3_REGION}
+    cloudfront:
+      media-base-url: https://ignoa.woomin.dev
+
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- closes: #126

---

## 📝 작업 내용 (Description)

비공개 S3 미디어 객체를 CloudFront를 통해 제공하도록 이미지 조회 경로를 변경했습니다.

- 미디어 S3 Origin에 OAC와 Bucket Policy 적용
- `/items/*`, `/profiles/*` 요청을 미디어 S3 Origin으로 라우팅
- CloudFront 미디어 기본 URL 프로퍼티 추가
- `MediaUrlResolver`가 Object Key를 CloudFront URL로 변환하도록 변경
- 외부 프로필 이미지는 기존 외부 URL을 그대로 반환
- EC2 IAM Policy에서 불필요한 `s3:GetObject` 권한 제거

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 셀프 리뷰를 진행했습니다
- [x] `./gradlew compileJava`가 통과했습니다
- [x] CloudFront URL로 상품 이미지를 조회했습니다
- [ ] EC2 재배포 후 API가 CloudFront 기반 이미지 URL을 반환하는지 확인합니다
- [ ] 상품·프로필 이미지가 실제 화면에서 정상적으로 표시되는지 확인합니다
