### PR TITLE
feat: Tika 기반 미디어 파일 업로드 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 	// 유효성 검사
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.apache.tika:tika-core:3.3.2'
 
 	// 외부 서비스
 	implementation 'software.amazon.awssdk:s3:2.26.12'

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일은 업로드할 수 없습니다."),
 
     // Wish
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "찜을 찾을 수 없습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일은 업로드할 수 없습니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 파일 크기를 초과했습니다."),
 
     // Wish
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "찜을 찾을 수 없습니다."),

--- a/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -81,6 +82,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.MISSING_REFRESH_TOKEN.getHttpStatus())
                 .body(ErrorResponse.of(ErrorCode.MISSING_REFRESH_TOKEN));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException e) {
+        log.warn("MaxUploadSizeExceededException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.FILE_SIZE_EXCEEDED.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageService.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageService.java
@@ -26,6 +26,10 @@ public class StorageService {
     private String bucket;
 
     public String upload(MultipartFile file, ObjectKeyPrefix prefix) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.EMPTY_FILE);
+        }
+
         try {
             String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
 

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageService.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageService.java
@@ -1,60 +1,70 @@
 package io.wisoft.ignoa_api.global.infra.storage;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.tika.Tika;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import org.springframework.beans.factory.annotation.Value;
 
 import io.wisoft.ignoa_api.global.exception.BusinessException;
 import io.wisoft.ignoa_api.global.exception.ErrorCode;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class StorageService {
 
+    private static final Map<String, String> ALLOWED_MEDIA_TYPES = Map.of(
+            "image/jpeg", "jpg",
+            "image/png", "png",
+            "image/gif", "gif",
+            "image/webp", "webp",
+            "video/mp4", "mp4",
+            "video/quicktime", "mov",
+            "video/x-msvideo", "avi",
+            "video/webm", "webm"
+    );
+
     private final S3Client s3Client;
+    private final Tika tika = new Tika();
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile file, ObjectKeyPrefix prefix) {
+    public StorageUploadResult upload(MultipartFile file, ObjectKeyPrefix prefix) {
         if (file == null || file.isEmpty()) {
             throw new BusinessException(ErrorCode.EMPTY_FILE);
         }
 
-        try {
-            String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        String contentType = detectContentType(file);
+        String extension = resolveExtension(contentType);
+        validateAllowedType(prefix, contentType);
 
-            if (!StringUtils.hasText(extension)) {
-                throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        String objectKey = "%s/%s.%s".formatted(
+                prefix.getValue(),
+                UUID.randomUUID(),
+                extension
+        );
 
-            }
-
-            String objectKey = "%s/%s.%s".formatted(
-                    prefix.getValue(),
-                    UUID.randomUUID(),
-                    extension
-            );
-
+        try (InputStream inputStream = file.getInputStream()) {
             s3Client.putObject(
                     PutObjectRequest.builder()
                             .bucket(bucket)
                             .key(objectKey)
-                            .contentType(file.getContentType())
+                            .contentType(contentType)
                             .build(),
-                    RequestBody.fromBytes(file.getBytes())
+                    RequestBody.fromInputStream(inputStream, file.getSize())
             );
 
-            return objectKey;
-
+            return new StorageUploadResult(objectKey, contentType);
         } catch (IOException e) {
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
@@ -71,5 +81,29 @@ public class StorageService {
                         .key(objectKey)
                         .build()
         );
+    }
+
+    private String detectContentType(MultipartFile file) {
+        try (InputStream inputStream = file.getInputStream()) {
+            return tika.detect(inputStream);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String resolveExtension(String contentType) {
+        String extension = ALLOWED_MEDIA_TYPES.get(contentType);
+
+        if (extension == null) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        return extension;
+    }
+
+    private void validateAllowedType(ObjectKeyPrefix prefix, String contentType) {
+        if (prefix == ObjectKeyPrefix.PROFILES && !contentType.startsWith("image/")) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_MEDIA_TYPE);
+        }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageUploadResult.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/infra/storage/StorageUploadResult.java
@@ -1,0 +1,7 @@
+package io.wisoft.ignoa_api.global.infra.storage;
+
+public record StorageUploadResult(
+        String objectKey,
+        String contentType
+) {
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/entity/enums/ItemMediaType.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/entity/enums/ItemMediaType.java
@@ -9,7 +9,7 @@ public enum ItemMediaType {
     IMAGE, VIDEO;
 
     private static final Set<String> IMAGE_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
-    private static final Set<String> VIDEO_TYPES = Set.of("video/mp4", "video/quicktime", "video/avi", "video/webm");
+    private static final Set<String> VIDEO_TYPES = Set.of("video/mp4", "video/quicktime", "video/x-msvideo", "video/webm");
 
     public static ItemMediaType from(String contentType) {
         if (contentType == null) throw new BusinessException(ErrorCode.UNSUPPORTED_MEDIA_TYPE);

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -6,6 +6,7 @@ import io.wisoft.ignoa_api.global.infra.lock.LockOperation;
 import io.wisoft.ignoa_api.global.infra.lock.RedissonDistributedLock;
 import io.wisoft.ignoa_api.global.infra.storage.ObjectKeyPrefix;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
+import io.wisoft.ignoa_api.global.infra.storage.StorageUploadResult;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
 import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
 import io.wisoft.ignoa_api.item.dto.request.ItemBuyNowRequest;
@@ -92,14 +93,18 @@ public class ItemFacade {
     }
 
     private void uploadFiles(List<MultipartFile> files, List<UploadedMedia> uploadedMedias) {
-        // 상품 수정 시 새로 업로드할 파일이 없으면 생략
         if (CollectionUtils.isEmpty(files)) {
             return;
         }
 
         for (MultipartFile file : files) {
-            String objectKey = storageService.upload(file, ObjectKeyPrefix.ITEMS);
-            uploadedMedias.add(new UploadedMedia(objectKey, ItemMediaType.from(file.getContentType())));
+            StorageUploadResult uploadResult = storageService.upload(file, ObjectKeyPrefix.ITEMS);
+            uploadedMedias.add(
+                    new UploadedMedia(
+                            uploadResult.objectKey(),
+                            ItemMediaType.from(uploadResult.contentType())
+                    )
+            );
         }
     }
 

--- a/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/service/ItemFacade.java
@@ -92,6 +92,7 @@ public class ItemFacade {
     }
 
     private void uploadFiles(List<MultipartFile> files, List<UploadedMedia> uploadedMedias) {
+        // 상품 수정 시 새로 업로드할 파일이 없으면 생략
         if (CollectionUtils.isEmpty(files)) {
             return;
         }

--- a/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
+++ b/src/main/java/io/wisoft/ignoa_api/user/service/UserFacade.java
@@ -5,6 +5,7 @@ import io.wisoft.ignoa_api.auth.service.TokenBlacklistService;
 import io.wisoft.ignoa_api.global.infra.storage.MediaUrlResolver;
 import io.wisoft.ignoa_api.global.infra.storage.ObjectKeyPrefix;
 import io.wisoft.ignoa_api.global.infra.storage.StorageService;
+import io.wisoft.ignoa_api.global.infra.storage.StorageUploadResult;
 import io.wisoft.ignoa_api.global.outbox.entity.OutboxEventType;
 import io.wisoft.ignoa_api.global.outbox.service.OutboxAppender;
 import io.wisoft.ignoa_api.user.dto.response.MyProfile;
@@ -30,7 +31,8 @@ public class UserFacade {
     private final TokenBlacklistService tokenBlacklistService;
 
     public MyProfile updateProfileImage(Long userId, MultipartFile image) {
-        String newObjectKey = storageService.upload(image, ObjectKeyPrefix.PROFILES);
+        StorageUploadResult uploadResult = storageService.upload(image, ObjectKeyPrefix.PROFILES);
+        String newObjectKey = uploadResult.objectKey();
 
         User user;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,7 +36,6 @@ cloud:
     cloudfront:
       media-base-url: https://ignoa.woomin.dev
 
-
 jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${JWT_ACCESS_EXPIRATION}


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- closes: #127

---

## 📝 작업 내용 (Description)

클라이언트가 전달한 파일명과 `Content-Type` 대신 실제 파일 내용을 검사한 뒤, 검증을 통과한 미디어만 S3에 업로드하도록 개선했습니다.

- Apache Tika를 이용해 실제 MIME 타입 판별
- 빈 파일과 지원하지 않는 파일을 S3 업로드 전에 차단
- 상품에는 이미지·동영상, 프로필에는 이미지만 허용
- 검증된 MIME 타입으로 Object Key 확장자와 S3 `Content-Type` 결정
- 상품의 `IMAGE`·`VIDEO` 타입도 검증된 MIME 타입으로 결정
- `getBytes()` 대신 `InputStream` 기반 S3 업로드 적용
- Multipart 크기 초과 시 `413 Payload Too Large` 응답

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 관련 이슈의 완료 조건을 충족했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] `./gradlew test`가 통과했습니다
- [x] `git diff --check`가 통과했습니다
- [ ] EC2 재배포 후 정상 파일과 위장 파일 업로드를 검증합니다

---

## 💬 추가 코멘트 (Additional Comments)

- 기존 Multipart 제한인 파일당 `100MB`, 요청당 `200MB`는 유지했습니다.
- Tika는 실제 파일 형식을 판별하며 악성코드 검사는 이번 작업 범위에 포함하지 않았습니다.
