### PR TITLE
test: 경매 자동 마감 정합성 통합 테스트 추가

### DIFF
--- a/src/test/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJobIntegrationTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJobIntegrationTest.java
@@ -1,0 +1,188 @@
+package io.wisoft.ignoa_api.auction.scheduler;
+
+import io.wisoft.ignoa_api.auction.service.AuctionService;
+import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
+import io.wisoft.ignoa_api.bid.entity.Bid;
+import io.wisoft.ignoa_api.bid.entity.BidStatus;
+import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.bid.service.BidService;
+import io.wisoft.ignoa_api.chat.entity.ChatRoom;
+import io.wisoft.ignoa_api.chat.repository.ChatRoomRepository;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.support.IntegrationTestSupport;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuctionCloseJobIntegrationTest extends IntegrationTestSupport {
+
+    @MockitoBean
+    AuctionCloseScheduler auctionCloseScheduler;
+
+    @Autowired
+    AuctionCloseJob auctionCloseJob;
+
+    @Autowired
+    AuctionService auctionService;
+
+    @Autowired
+    BidService bidService;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    BidRepository bidRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        chatRoomRepository.deleteAllInBatch();
+        bidRepository.deleteAllInBatch();
+        itemRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 입찰이_없는_만료_경매만_유찰_처리한다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        Item expiredItem = itemRepository.save(
+                newItem(seller, LocalDateTime.now().minusMinutes(1))
+        );
+        Item activeItem = itemRepository.save(
+                newItem(seller, LocalDateTime.now().plusDays(1))
+        );
+
+        // When
+        auctionCloseJob.closeExpiredAuctions();
+
+        // Then
+        Item closedItem = itemRepository.findById(expiredItem.getId()).orElseThrow();
+        Item unchangedItem = itemRepository.findById(activeItem.getId()).orElseThrow();
+
+        assertThat(closedItem.getStatus()).isEqualTo(ItemStatus.NO_BID_CLOSED);
+        assertThat(unchangedItem.getStatus()).isEqualTo(ItemStatus.ACTIVE);
+        assertThat(chatRoomRepository.count()).isZero();
+    }
+
+    @Test
+    void 입찰이_있는_만료_경매는_낙찰과_패찰을_결정하고_채팅방을_한번만_생성한다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User firstBidder = userRepository.save(newUser("bidder1@test.com", "입찰자1"));
+        User winningBidder = userRepository.save(newUser("bidder2@test.com", "입찰자2"));
+        Item item = itemRepository.save(newItem(seller));
+
+        bidService.placeBid(item.getId(), firstBidder.getId(), new BidCreateRequest(1_500L));
+        bidService.placeBid(item.getId(), winningBidder.getId(), new BidCreateRequest(2_000L));
+        expire(item.getId(), LocalDateTime.now().minusMinutes(1));
+
+        // When
+        auctionCloseJob.closeExpiredAuctions();
+        auctionCloseJob.closeExpiredAuctions();
+
+        // Then
+        Item closedItem = itemRepository.findById(item.getId()).orElseThrow();
+        Map<Long, BidStatus> statusByPrice = bidRepository.findByItemId(item.getId()).stream()
+                .collect(Collectors.toMap(Bid::getPrice, Bid::getStatus));
+        List<ChatRoom> chatRooms = chatRoomRepository.findAll();
+
+        assertThat(closedItem.getStatus()).isEqualTo(ItemStatus.BID_CLOSED);
+        assertThat(closedItem.getHighestBidder().getId()).isEqualTo(winningBidder.getId());
+        assertThat(statusByPrice)
+                .hasSize(2)
+                .containsEntry(1_500L, BidStatus.LOST)
+                .containsEntry(2_000L, BidStatus.WON);
+        assertThat(chatRooms).singleElement().satisfies(chatRoom -> {
+            assertThat(chatRoom.getItem().getId()).isEqualTo(item.getId());
+            assertThat(chatRoom.getSeller().getId()).isEqualTo(seller.getId());
+            assertThat(chatRoom.getBuyer().getId()).isEqualTo(winningBidder.getId());
+        });
+    }
+
+    @Test
+    void 분산_락_없이_동시에_마감해도_조건부_UPDATE로_한번만_처리한다() throws InterruptedException {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User firstBidder = userRepository.save(newUser("bidder1@test.com", "입찰자1"));
+        User winningBidder = userRepository.save(newUser("bidder2@test.com", "입찰자2"));
+        Item item = itemRepository.save(newItem(seller));
+
+        bidService.placeBid(item.getId(), firstBidder.getId(), new BidCreateRequest(1_500L));
+        bidService.placeBid(item.getId(), winningBidder.getId(), new BidCreateRequest(2_000L));
+        expire(item.getId(), LocalDateTime.now().minusMinutes(1));
+
+        int threadCount = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        Queue<Throwable> unexpectedErrors = new ConcurrentLinkedQueue<>();
+
+        // When
+        try (ExecutorService executor = Executors.newFixedThreadPool(threadCount)) {
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        auctionService.closeAuction(item.getId());
+                    } catch (Throwable throwable) {
+                        unexpectedErrors.add(throwable);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        // Then
+        Item closedItem = itemRepository.findById(item.getId()).orElseThrow();
+        Map<Long, BidStatus> statusByPrice = bidRepository.findByItemId(item.getId()).stream()
+                .collect(Collectors.toMap(Bid::getPrice, Bid::getStatus));
+
+        assertThat(unexpectedErrors).isEmpty();
+        assertThat(closedItem.getStatus()).isEqualTo(ItemStatus.BID_CLOSED);
+        assertThat(statusByPrice)
+                .hasSize(2)
+                .containsEntry(1_500L, BidStatus.LOST)
+                .containsEntry(2_000L, BidStatus.WON);
+        assertThat(chatRoomRepository.count()).isEqualTo(1L);
+    }
+
+    private void expire(Long itemId, LocalDateTime endAt) {
+        jdbcTemplate.update(
+                "UPDATE items SET end_at = ? WHERE id = ?",
+                endAt,
+                itemId
+        );
+    }
+}

--- a/src/test/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJobRollbackIntegrationTest.java
+++ b/src/test/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJobRollbackIntegrationTest.java
@@ -1,0 +1,116 @@
+package io.wisoft.ignoa_api.auction.scheduler;
+
+import io.wisoft.ignoa_api.bid.dto.request.BidCreateRequest;
+import io.wisoft.ignoa_api.bid.entity.Bid;
+import io.wisoft.ignoa_api.bid.entity.BidStatus;
+import io.wisoft.ignoa_api.bid.repository.BidRepository;
+import io.wisoft.ignoa_api.bid.service.BidService;
+import io.wisoft.ignoa_api.chat.service.ChatRoomService;
+import io.wisoft.ignoa_api.item.entity.Item;
+import io.wisoft.ignoa_api.item.entity.enums.ItemStatus;
+import io.wisoft.ignoa_api.item.repository.ItemRepository;
+import io.wisoft.ignoa_api.support.IntegrationTestSupport;
+import io.wisoft.ignoa_api.user.entity.User;
+import io.wisoft.ignoa_api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class AuctionCloseJobRollbackIntegrationTest extends IntegrationTestSupport {
+
+    @MockitoBean
+    AuctionCloseScheduler auctionCloseScheduler;
+
+    @MockitoBean
+    ChatRoomService chatRoomService;
+
+    @Autowired
+    AuctionCloseJob auctionCloseJob;
+
+    @Autowired
+    BidService bidService;
+
+    @Autowired
+    BidRepository bidRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        bidRepository.deleteAllInBatch();
+        itemRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 한_경매의_후속_처리가_실패해도_다른_경매를_계속_마감하고_다음_주기에_재시도한다() {
+        // Given
+        User seller = userRepository.save(newUser("seller@test.com", "판매자"));
+        User bidder = userRepository.save(newUser("bidder@test.com", "입찰자"));
+
+        Item retryItem = itemRepository.save(newItem(seller));
+        bidService.placeBid(retryItem.getId(), bidder.getId(), new BidCreateRequest(2_000L));
+        expire(retryItem.getId(), LocalDateTime.now().minusMinutes(2));
+
+        Item noBidItem = itemRepository.save(
+                newItem(seller, LocalDateTime.now().minusMinutes(1))
+        );
+
+        doThrow(new RuntimeException("채팅방 생성 실패"))
+                .doNothing()
+                .when(chatRoomService)
+                .createChat(retryItem.getId());
+
+        // When: 첫 번째 실행에서 retryItem은 롤백되고, noBidItem은 계속 처리된다.
+        auctionCloseJob.closeExpiredAuctions();
+
+        // Then
+        Item rolledBackItem = itemRepository.findById(retryItem.getId()).orElseThrow();
+        Item closedNoBidItem = itemRepository.findById(noBidItem.getId()).orElseThrow();
+
+        assertThat(rolledBackItem.getStatus()).isEqualTo(ItemStatus.ACTIVE);
+        assertThat(bidRepository.findByItemId(retryItem.getId()))
+                .singleElement()
+                .extracting(Bid::getStatus)
+                .isEqualTo(BidStatus.ACTIVE);
+        assertThat(closedNoBidItem.getStatus()).isEqualTo(ItemStatus.NO_BID_CLOSED);
+
+        // When: 다음 실행에서 롤백된 경매를 다시 처리한다.
+        auctionCloseJob.closeExpiredAuctions();
+
+        // Then
+        Item retriedItem = itemRepository.findById(retryItem.getId()).orElseThrow();
+
+        assertThat(retriedItem.getStatus()).isEqualTo(ItemStatus.BID_CLOSED);
+        assertThat(bidRepository.findByItemId(retryItem.getId()))
+                .singleElement()
+                .extracting(Bid::getStatus)
+                .isEqualTo(BidStatus.WON);
+        verify(chatRoomService, times(2)).createChat(retryItem.getId());
+    }
+
+    private void expire(Long itemId, LocalDateTime endAt) {
+        jdbcTemplate.update(
+                "UPDATE items SET end_at = ? WHERE id = ?",
+                endAt,
+                itemId
+        );
+    }
+}

--- a/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
+++ b/src/test/java/io/wisoft/ignoa_api/support/IntegrationTestSupport.java
@@ -44,6 +44,10 @@ public abstract class IntegrationTestSupport {
     }
 
     protected Item newItem(User seller) {
+        return newItem(seller, LocalDateTime.now().plusDays(1));
+    }
+
+    protected Item newItem(User seller, LocalDateTime endAt) {
         return Item.create(
                 seller,
                 "테스트 상품",
@@ -53,7 +57,7 @@ public abstract class IntegrationTestSupport {
                 "브랜드",
                 1_000L,
                 1_000_000L,
-                LocalDateTime.now().plusDays(1)
+                endAt
         );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- related to: #139

---

## 📝 작업 내용 (Description)

DB 폴링 기반 경매 자동 마감의 상태 전이와 트랜잭션 정합성을 실제 MySQL·Redis 환경에서 검증하는 통합 테스트를 추가했습니다.

- 입찰 없는 만료 경매의 `NO_BID_CLOSED` 전환 검증
- 마감되지 않은 경매가 조회 대상에서 제외되는지 검증
- 최고가 입찰 `WON`, 나머지 입찰 `LOST` 처리 검증
- 낙찰자와 판매자의 채팅방이 한 번만 생성되는지 검증
- 분산 락 없이 10개 Thread가 동시에 마감해도 조건부 UPDATE로 한 번만 처리되는지 검증
- 채팅방 생성 실패 시 상품·입찰 상태가 모두 롤백되는지 검증
- 한 경매의 실패가 다른 경매의 마감을 막지 않는지 검증
- 롤백된 경매가 다음 실행에서 재처리되는지 검증
- 종료 시각을 지정할 수 있도록 공통 Item Test Fixture 확장

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [x] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] 경매 자동 마감의 정상·중복·실패 시나리오를 검증했습니다
- [x] 셀프 리뷰를 진행했습니다
- [x] 전체 `./gradlew test`가 통과했습니다
- [x] `git diff --check`가 통과했습니다

---

## 💬 추가 코멘트 (Additional Comments)

- 자동 Scheduler가 테스트 도중 개입하지 않도록 Scheduler Bean만 Mock 처리했습니다.
- `AuctionCloseJob`, Service, Repository와 MySQL·Redis Testcontainers는 실제 구성을 사용했습니다.
- 1,000건 동시 만료 성능 측정과 Worker Pool 병렬화는 후속 작업으로 분리했습니다.
