### PR TITLE
feat: 경매 자동 마감 성능 측정 지표 추가

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/metric/AuctionCloseMetrics.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/metric/AuctionCloseMetrics.java
@@ -1,0 +1,44 @@
+package io.wisoft.ignoa_api.auction.metric;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuctionCloseMetrics {
+
+    private final MeterRegistry meterRegistry;
+    private final Timer jobDuration;
+    private final Counter completedItems;
+    private final Counter failedItems;
+
+    public AuctionCloseMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+
+        this.jobDuration = Timer.builder("auction.close.job.duration")
+                .description("경매 자동 마감 Job 전체 처리 시간")
+                .register(meterRegistry);
+
+        this.completedItems = Counter.builder("auction.close.items")
+                .description("경매 자동 마감 상품 처리 건수")
+                .tag("outcome", "completed")
+                .register(meterRegistry);
+
+        this.failedItems = Counter.builder("auction.close.items")
+                .description("경매 자동 마감 상품 처리 건수")
+                .tag("outcome", "failed")
+                .register(meterRegistry);
+    }
+
+    public Timer.Sample start() {
+        return Timer.start(meterRegistry);
+    }
+
+    public long record(Timer.Sample sample, int completedCount, int failedCount) {
+        completedItems.increment(completedCount);
+        failedItems.increment(failedCount);
+
+        return sample.stop(jobDuration);
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
@@ -1,5 +1,7 @@
 package io.wisoft.ignoa_api.auction.scheduler;
 
+import io.micrometer.core.instrument.Timer;
+import io.wisoft.ignoa_api.auction.metric.AuctionCloseMetrics;
 import io.wisoft.ignoa_api.auction.service.AuctionFacade;
 import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
@@ -9,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -18,14 +21,42 @@ public class AuctionCloseJob {
     private final AuctionFacade auctionFacade;
     private final ItemRepository itemRepository;
 
-    public void closeExpiredAuctions() {
-        List<Item> expiredItems = itemRepository.findExpiredActiveItems(LocalDateTime.now());
+    private final AuctionCloseMetrics auctionCloseMetrics;
 
-        for (Item item : expiredItems) {
-            try {
-                auctionFacade.closeAuction(item.getId());
-            } catch (Exception e) {
-                log.error("만료 경매 마감 처리 실패 itemId={}", item.getId(), e);
+    public void closeExpiredAuctions() {
+        Timer.Sample sample = auctionCloseMetrics.start();
+
+        int selectedCount = 0;
+        int completedCount = 0;
+        int failedCount = 0;
+
+        try {
+            List<Item> expiredItems = itemRepository.findExpiredActiveItems(LocalDateTime.now());
+
+            selectedCount = expiredItems.size();
+
+            for (Item item : expiredItems) {
+                try {
+                    auctionFacade.closeAuction(item.getId());
+                    completedCount++;
+                } catch (Exception e) {
+                    failedCount++;
+                    log.error("만료 경매 마감 처리 실패 itemId={}", item.getId(), e);
+                }
+            }
+        } finally {
+            long durationNanos = auctionCloseMetrics.record(
+                    sample, completedCount, failedCount
+            );
+
+            if (selectedCount > 0) {
+                log.info(
+                        "경매 자동 마감 Job 완료: selected={}, completed={}, failed={}, durationMs={}",
+                        selectedCount,
+                        completedCount,
+                        failedCount,
+                        TimeUnit.NANOSECONDS.toMillis(durationNanos)
+                );
             }
         }
     }

--- a/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/service/AuctionService.java
@@ -24,7 +24,6 @@ public class AuctionService {
 
     private final BidService bidService;
     private final ChatRoomService chatRoomService;
-
     private final ItemReader itemReader;
     private final ItemRepository itemRepository;
 


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- related to: #142

---

## 📝 작업 내용 (Description)

경매 자동 마감의 처리 시간과 결과를 관찰할 수 있도록 Micrometer 지표를 추가했습니다.

- 자동 마감 Job 전체 처리 시간을 `Timer`로 측정
- 예외 없이 완료된 상품과 실패한 상품 수를 `Counter`로 기록
- 지표 생성과 기록 책임을 `AuctionCloseMetrics`로 분리
- 조회·완료·실패 건수와 처리 시간을 Job 완료 로그로 기록

---

## 🔄 변경 유형 (Type of Change)

- [x] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] Job당 한 번만 처리 시간과 결과를 기록하도록 구성했습니다
- [x] 지표 관리 책임을 비즈니스 처리 흐름과 분리했습니다
- [x] `./gradlew compileJava`가 통과했습니다
- [ ] EC2 재배포 후 Prometheus와 Grafana에서 지표를 검증합니다

---

## 💬 추가 코멘트 (Additional Comments)

- Worker Pool 적용 전 동기 처리 기준값을 측정하기 위한 지표입니다.
- 병렬 처리 구현과 전후 성능 비교는 후속 작업으로 진행합니다.