### PR TITLE
perf: Worker Pool 기반 경매 자동 마감 병렬 처리

### DIFF
--- a/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
+++ b/src/main/java/io/wisoft/ignoa_api/auction/scheduler/AuctionCloseJob.java
@@ -3,61 +3,88 @@ package io.wisoft.ignoa_api.auction.scheduler;
 import io.micrometer.core.instrument.Timer;
 import io.wisoft.ignoa_api.auction.metric.AuctionCloseMetrics;
 import io.wisoft.ignoa_api.auction.service.AuctionFacade;
-import io.wisoft.ignoa_api.item.entity.Item;
 import io.wisoft.ignoa_api.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuctionCloseJob {
 
+    private static final int BATCH_SIZE = 1_000;
+
     private final AuctionFacade auctionFacade;
     private final ItemRepository itemRepository;
-
     private final AuctionCloseMetrics auctionCloseMetrics;
+    private final Executor auctionCloseExecutor;
 
     public void closeExpiredAuctions() {
         Timer.Sample sample = auctionCloseMetrics.start();
 
         int selectedCount = 0;
-        int completedCount = 0;
-        int failedCount = 0;
+
+        AtomicInteger completedCount = new AtomicInteger();
+        AtomicInteger failedCount = new AtomicInteger();
 
         try {
-            List<Item> expiredItems = itemRepository.findExpiredActiveItems(LocalDateTime.now());
+            List<Long> expiredItemIds = itemRepository.findExpiredActiveItemIds(
+                    LocalDateTime.now(),
+                    PageRequest.of(0, BATCH_SIZE)
+            );
 
-            selectedCount = expiredItems.size();
+            selectedCount = expiredItemIds.size();
 
-            for (Item item : expiredItems) {
-                try {
-                    auctionFacade.closeAuction(item.getId());
-                    completedCount++;
-                } catch (Exception e) {
-                    failedCount++;
-                    log.error("만료 경매 마감 처리 실패 itemId={}", item.getId(), e);
-                }
-            }
+            List<CompletableFuture<Void>> futures = expiredItemIds.stream()
+                    .map(itemId -> CompletableFuture.runAsync(
+                            () -> closeAuction(itemId, completedCount, failedCount),
+                            auctionCloseExecutor
+                    ))
+                    .toList();
+
+            CompletableFuture.allOf(
+                    futures.toArray(CompletableFuture[]::new)
+            ).join();
+
         } finally {
             long durationNanos = auctionCloseMetrics.record(
-                    sample, completedCount, failedCount
+                    sample,
+                    completedCount.get(),
+                    failedCount.get()
             );
 
             if (selectedCount > 0) {
                 log.info(
                         "경매 자동 마감 Job 완료: selected={}, completed={}, failed={}, durationMs={}",
                         selectedCount,
-                        completedCount,
-                        failedCount,
+                        completedCount.get(),
+                        failedCount.get(),
                         TimeUnit.NANOSECONDS.toMillis(durationNanos)
                 );
             }
+        }
+    }
+
+    private void closeAuction(
+            Long itemId,
+            AtomicInteger completedCount,
+            AtomicInteger failedCount
+    ) {
+        try {
+            auctionFacade.closeAuction(itemId);
+            completedCount.incrementAndGet();
+        } catch (Exception e) {
+            failedCount.incrementAndGet();
+            log.error("만료 경매 마감 처리 실패 itemId={}", itemId, e);
         }
     }
 }

--- a/src/main/java/io/wisoft/ignoa_api/global/config/AuctionCloseExecutorConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/AuctionCloseExecutorConfig.java
@@ -1,0 +1,30 @@
+package io.wisoft.ignoa_api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AuctionCloseExecutorConfig {
+
+    private static final int WORKER_COUNT = 4;
+    private static final int QUEUE_CAPACITY = 1_000;
+
+    @Bean
+    public Executor auctionCloseExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(WORKER_COUNT);
+        executor.setMaxPoolSize(WORKER_COUNT);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix("auction-close-");
+
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
+++ b/src/main/java/io/wisoft/ignoa_api/item/repository/ItemRepository.java
@@ -68,13 +68,13 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     // 경매 마감 - 만료된 상품 조회
     @Query("""
-            SELECT i
+            SELECT i.id
             FROM Item i
             WHERE i.status = 'ACTIVE'
                 AND i.endAt <= :now
             ORDER BY i.endAt ASC, i.id ASC
             """)
-    List<Item> findExpiredActiveItems(@Param("now") LocalDateTime now);
+    List<Long> findExpiredActiveItemIds(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 입찰 조건부 UPDATE
     @Modifying


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- related to: #142

---

## 📝 작업 내용 (Description)

순차 실행하던 경매 자동 마감을 전용 Worker Pool 기반 병렬 처리로 전환했습니다.

- 만료 경매를 전체 Entity 대신 ID로 최대 1,000건 조회
- 경매 마감 전용 고정 Worker Pool 4개 구성
- `CompletableFuture`로 상품별 마감 작업 병렬 실행
- `allOf().join()`으로 전체 작업 완료 후 Job 종료
- `AtomicInteger`로 병렬 환경의 완료·실패 건수 집계
- 기존 상품별 독립 트랜잭션과 조건부 UPDATE 유지

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [x] 🔧 기타 (perf)

---

## ✅ 체크리스트 (Checklist)

- [x] Worker 수를 4개로 제한했습니다
- [x] 한 번에 조회하는 마감 대상을 최대 1,000건으로 제한했습니다
- [x] 전체 작업 완료 후 처리 시간과 결과를 기록하도록 구성했습니다
- [x] 경매 마감 및 롤백 통합 테스트가 통과했습니다
- [x] `./gradlew compileJava`와 `git diff --check`가 통과했습니다
- [x] EC2 재배포 후 동일한 1,000건 조건으로 성능을 비교합니다

---

## 💬 추가 코멘트 (Additional Comments)

- 순차 처리 기준선은 두 차례 측정 평균 약 13.12초입니다.
- HikariCP 최대 10개 중 일반 API용 여유를 남기기 위해 Worker를 4개로 고정했습니다.
- 배포 후 처리 시간, 처리량, HikariCP, CPU, DB Timeout과 Redis 락 대기 지표를 확인합니다.
