### PR TITLE
refactor: ShedLock 잠금 저장소를 JDBC로 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-	// 웹/서버
+	// 웹, 서버
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// 보안/인증
+	// 보안, 인증
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
@@ -52,7 +52,7 @@ dependencies {
 
 	// Shedlock
 	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.0.2'
-	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.0.2'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.0.2'
 
 	// 분산 락
 	implementation 'org.redisson:redisson:4.6.1'

--- a/src/main/java/io/wisoft/ignoa_api/global/config/ShedLockConfig.java
+++ b/src/main/java/io/wisoft/ignoa_api/global/config/ShedLockConfig.java
@@ -1,18 +1,25 @@
 package io.wisoft.ignoa_api.global.config;
 
 import net.javacrumbs.shedlock.core.LockProvider;
-import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
 
 @Configuration
 @EnableSchedulerLock(defaultLockAtMostFor = "10m")
 public class ShedLockConfig {
 
     @Bean
-    LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
-        return new RedisLockProvider(connectionFactory);
+    LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 (Related Issue)

- closes: #124

---

## 📝 작업 내용 (Description)

DB Polling Scheduler의 잠금 저장소를 Redis에서 MySQL로 전환했습니다.

- ShedLock Provider 의존성을 Redis용에서 JDBC용으로 교체
- `JdbcTemplateLockProvider`에 기존 Spring `DataSource` 연결
- `usingDbTime()`을 적용해 MySQL 시간을 잠금 기준으로 사용
- 기존 `@SchedulerLock` 적용 위치와 실행 주기 유지
- 입찰 등 비즈니스 요청의 Redisson 분산 락은 유지

---

## 🔄 변경 유형 (Type of Change)

- [ ] ✨ 새로운 기능 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 수정 (docs)
- [ ] 💄 스타일 (style)
- [x] ♻️ 리팩토링 (refactor)
- [ ] ✅ 테스트 (test)
- [ ] 🔧 기타 (chore)

---

## ✅ 체크리스트 (Checklist)

- [x] JDBC Provider가 기존 MySQL `DataSource`를 사용하도록 구성했습니다
- [x] 여러 인스턴스의 시각 차이를 피하도록 `usingDbTime()`을 적용했습니다
- [x] `./gradlew compileJava`가 통과했습니다
- [x] `git diff --check`가 통과했습니다
- [ ] EC2 재배포 후 `shedlock` 레코드 생성과 잠금 해제를 확인합니다

---

## 💬 추가 코멘트 (Additional Comments)

- `shedlock` 테이블은 배포 대상 MySQL에 별도로 생성합니다.
- DB 스키마의 버전 관리는 추후 Flyway 도입 작업에서 정리할 예정입니다.
